### PR TITLE
[refactor/28] 상품 주문 API 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 주문 관련 에러
     LACK_OF_STOCK(HttpStatus.BAD_REQUEST, "ORDER4001", "재고가 부족합니다."),
     NULL_ITEMOPTION_ERROR(HttpStatus.BAD_REQUEST, "ORDER4002", "주문할 상품 옵션을 선택해주세요."),
+    NO_LOGIN_ORDER_NOT_AVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "ORDER4003", "비회원 주문 불가, 관리자에게 문의 바랍니다."),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),

--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "해당 카테고리가 존재하지 않습니다"),
 
     //Term
-    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "해당 약관이 존재하지 않습니다.");
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "해당 약관이 존재하지 않습니다."),
 
     //tag error
     TAG_NOT_FOUND(HttpStatus.BAD_REQUEST, "TAG4001", "존재하지 않는 태그입니다.");

--- a/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
@@ -45,6 +45,7 @@ public class MemberConverter {
                 .memberRole(MemberRole.BUYER)
                 .memberCategoryList(new ArrayList<>())
                 .memberTermList(new ArrayList<>())
+                .itemList(new ArrayList<>())
                 .build();
 
     }

--- a/src/main/java/com/umc/TheGoods/converter/order/OrderConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/order/OrderConverter.java
@@ -2,6 +2,7 @@ package com.umc.TheGoods.converter.order;
 
 import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.order.OrderDetail;
+import com.umc.TheGoods.domain.order.OrderItem;
 import com.umc.TheGoods.domain.order.Orders;
 import com.umc.TheGoods.domain.types.PayType;
 import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
@@ -33,23 +34,41 @@ public class OrderConverter {
         return Orders.builder()
                 .name(request.getName())
                 .phone(request.getPhone())
-                .zipcode(request.getZipcode())
-                .address(request.getAddress())
-                .addressDetail(request.getAddressDetail())
                 .payType(payType)
-                .refundBank(request.getRefundBank())
-                .refundAccount(request.getRefundAccount())
-                .refundOwner(request.getRefundOwner())
-                .orderDetailList(new ArrayList<>())
+                .orderItemList(new ArrayList<>())
                 .build();
     }
 
-    public static OrderDetail toOrderDetail(OrderRequestDTO.OrderItemDto orderItemDto, Long price) {
-        return OrderDetail.builder()
-                .amount(orderItemDto.getAmount())
-                .orderPrice(price)
+    public static OrderItem toOrderItem(OrderRequestDTO.OrderAddDto request, Integer deliveryFee) {
+        return OrderItem.builder()
+                .totalPrice(0L)
+                .deliveryFee(deliveryFee)
                 .status(OrderStatus.PAY_PREV)
+                .zipcode(request.getZipcode())
+                .address(request.getAddress())
+                .addressDetail(request.getAddressDetail())
+                .deliveryMemo(request.getDeliveryMemo())
+                .refundBank(request.getRefundBank())
+                .refundAccount(request.getRefundAccount())
+                .refundOwner(request.getRefundOwner())
+                .depositor(request.getDepositor())
+                .orderDetailList(new ArrayList<>())
                 .build();
     }
+    
+    public static OrderDetail toOrderDetail(OrderRequestDTO.OrderDetailDTO orderDetailDTO, Long price) {
+        return OrderDetail.builder()
+                .amount(orderDetailDTO.getAmount())
+                .orderPrice(orderDetailDTO.getAmount() * price)
+                .build();
+    }
+
+//    public static OrderDetail toOrderDetail(OrderRequestDTO.OrderItemDto orderItemDto, Long price) {
+//        return OrderDetail.builder()
+//                .amount(orderItemDto.getAmount())
+//                .orderPrice(price)
+//                .status(OrderStatus.PAY_PREV)
+//                .build();
+//    }
 
 }

--- a/src/main/java/com/umc/TheGoods/domain/enums/MemberRole.java
+++ b/src/main/java/com/umc/TheGoods/domain/enums/MemberRole.java
@@ -1,5 +1,5 @@
 package com.umc.TheGoods.domain.enums;
 
 public enum MemberRole {
-    BUYER, SELLER
+    BUYER, SELLER, NOLOGIN
 }

--- a/src/main/java/com/umc/TheGoods/domain/item/Item.java
+++ b/src/main/java/com/umc/TheGoods/domain/item/Item.java
@@ -11,6 +11,7 @@ import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.OrderItem;
 import com.umc.TheGoods.domain.types.DeliveryType;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -34,6 +35,7 @@ public class Item extends BaseDateTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
+    @ColumnDefault("'ONSALE'")
     private ItemStatus status;
 
     @Column(length = 6)

--- a/src/main/java/com/umc/TheGoods/domain/item/Item.java
+++ b/src/main/java/com/umc/TheGoods/domain/item/Item.java
@@ -8,7 +8,7 @@ import com.umc.TheGoods.domain.mapping.Dibs;
 import com.umc.TheGoods.domain.mapping.Tag.ItemTag;
 import com.umc.TheGoods.domain.mapping.ViewSearch.ItemView;
 import com.umc.TheGoods.domain.member.Member;
-import com.umc.TheGoods.domain.order.OrderDetail;
+import com.umc.TheGoods.domain.order.OrderItem;
 import com.umc.TheGoods.domain.types.DeliveryType;
 import lombok.*;
 
@@ -85,7 +85,7 @@ public class Item extends BaseDateTimeEntity {
     private List<ItemOption> itemOptionList = new ArrayList<>();
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
-    private List<OrderDetail> orderDetailList = new ArrayList<>();
+    private List<OrderItem> orderItemList = new ArrayList<>();
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     private List<ItemTag> itemTagList = new ArrayList<>();
@@ -113,15 +113,15 @@ public class Item extends BaseDateTimeEntity {
         return this;
     }
 
-    public void setCategory(Category category){
-        if(this.category != null)
+    public void setCategory(Category category) {
+        if (this.category != null)
             category.getItemList().remove(this);
         this.category = category;
         category.getItemList().add(this);
     }
 
-    public void setMember(Member member){
-        if(this.member != null)
+    public void setMember(Member member) {
+        if (this.member != null)
             member.getItemList().remove(this);
         this.member = member;
         member.getItemList().add(this);

--- a/src/main/java/com/umc/TheGoods/domain/item/Review.java
+++ b/src/main/java/com/umc/TheGoods/domain/item/Review.java
@@ -4,7 +4,7 @@ import com.umc.TheGoods.domain.common.BaseDateTimeEntity;
 import com.umc.TheGoods.domain.enums.ReviewStatus;
 import com.umc.TheGoods.domain.images.ReviewImg;
 import com.umc.TheGoods.domain.member.Member;
-import com.umc.TheGoods.domain.order.OrderDetail;
+import com.umc.TheGoods.domain.order.OrderItem;
 import lombok.*;
 
 import javax.persistence.*;
@@ -40,8 +40,8 @@ public class Review extends BaseDateTimeEntity {
     private Item item;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_detail_id", nullable = false)
-    private OrderDetail orderDetail;
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
 
     @OneToOne(mappedBy = "review", cascade = CascadeType.ALL)
     private ReviewImg reviewImg;

--- a/src/main/java/com/umc/TheGoods/domain/item/Review.java
+++ b/src/main/java/com/umc/TheGoods/domain/item/Review.java
@@ -6,6 +6,7 @@ import com.umc.TheGoods.domain.images.ReviewImg;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.OrderItem;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 
@@ -29,6 +30,7 @@ public class Review extends BaseDateTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    @ColumnDefault("'SHOW'")
     private ReviewStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderCancel.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderCancel.java
@@ -25,6 +25,6 @@ public class OrderCancel extends BaseDateTimeEntity {
     private String reasonDetail;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_detail_id", nullable = false)
-    private OrderDetail orderDetail;
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderDetail.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderDetail.java
@@ -32,4 +32,20 @@ public class OrderDetail extends BaseDateTimeEntity {
     @JoinColumn(name = "item_option_id")
     private ItemOption itemOption;
 
+    public void setOrderItem(OrderItem orderItem) {
+        if (this.orderItem != null) {
+            this.orderItem.getOrderDetailList().remove(this);
+        }
+        this.orderItem = orderItem;
+        orderItem.getOrderDetailList().add(this);
+    }
+
+    public void setItemOption(ItemOption itemOption) {
+        if (this.itemOption != null) {
+            this.itemOption.getOrderDetailList().remove(this);
+        }
+        this.itemOption = itemOption;
+        itemOption.getOrderDetailList().add(this);
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderDetail.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderDetail.java
@@ -1,10 +1,7 @@
 package com.umc.TheGoods.domain.order;
 
 import com.umc.TheGoods.domain.common.BaseDateTimeEntity;
-import com.umc.TheGoods.domain.enums.OrderStatus;
-import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
-import com.umc.TheGoods.domain.item.Review;
 import lombok.*;
 
 import javax.persistence.*;
@@ -27,53 +24,12 @@ public class OrderDetail extends BaseDateTimeEntity {
     @Column(nullable = false)
     private Long orderPrice;
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
-    private OrderStatus status;
-
-    @Column(length = 30)
-    private String deliveryNum;
-
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "orders_id", nullable = false)
-    private Orders orders;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "item_id", nullable = false)
-    private Item item;
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_option_id")
     private ItemOption itemOption;
 
-    @OneToOne(mappedBy = "orderDetail", cascade = CascadeType.ALL)
-    private OrderCancel orderCancel;
-
-    @OneToOne(mappedBy = "orderDetail", cascade = CascadeType.ALL)
-    private Review review;
-
-    // 연관관계 메소드
-    public void setOrders(Orders orders) {
-        if (this.orders != null) {
-            this.orders.getOrderDetailList().remove(this);
-        }
-        this.orders = orders;
-        orders.getOrderDetailList().add(this);
-    }
-
-    public void setItem(Item item) {
-        if (this.item != null) {
-            this.item.getOrderDetailList().remove(this);
-        }
-        this.item = item;
-        item.getOrderDetailList().add(this);
-    }
-
-    public void setItemOption(ItemOption itemOption) {
-        if (this.itemOption != null) {
-            this.itemOption.getOrderDetailList().remove(this);
-        }
-        this.itemOption = itemOption;
-        itemOption.getOrderDetailList().add(this);
-    }
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
@@ -1,0 +1,71 @@
+package com.umc.TheGoods.domain.order;
+
+import com.umc.TheGoods.domain.common.BaseDateTimeEntity;
+import com.umc.TheGoods.domain.enums.OrderStatus;
+import com.umc.TheGoods.domain.item.Item;
+import com.umc.TheGoods.domain.item.Review;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OrderItem extends BaseDateTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long totalPrice;
+
+    @Column(nullable = false)
+    private Integer deliveryFee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    private OrderStatus status;
+
+    @Column(length = 30)
+    private String deliveryNum;
+
+    @Column(nullable = false, length = 10)
+    private String zipcode;
+
+    @Column(nullable = false, length = 300)
+    private String address;
+
+    private String addressDetail;
+
+    private String deliveryMemo;
+
+    @Column(nullable = false, length = 30)
+    private String refundBank;
+
+    @Column(nullable = false, length = 30)
+    private String refundAccount;
+
+    @Column(nullable = false, length = 20)
+    private String refundOwner;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orders_id", nullable = false)
+    private Orders orders;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL)
+    private List<OrderDetail> orderDetailList;
+
+    @OneToOne(mappedBy = "orderItem", cascade = CascadeType.ALL)
+    private OrderCancel orderCancel;
+
+    @OneToOne(mappedBy = "orderItem", cascade = CascadeType.ALL)
+    private Review review;
+}

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
@@ -5,8 +5,11 @@ import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.Review;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -28,6 +31,7 @@ public class OrderItem extends BaseDateTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    @ColumnDefault("'PAY_PREV'")
     private OrderStatus status;
 
     @Column(length = 30)
@@ -52,6 +56,11 @@ public class OrderItem extends BaseDateTimeEntity {
     @Column(nullable = false, length = 20)
     private String refundOwner;
 
+    @Column(length = 30)
+    private String depositor;
+
+    private LocalDate deposit_date;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "orders_id", nullable = false)
     private Orders orders;
@@ -61,11 +70,32 @@ public class OrderItem extends BaseDateTimeEntity {
     private Item item;
 
     @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL)
-    private List<OrderDetail> orderDetailList;
+    private List<OrderDetail> orderDetailList = new ArrayList<>();
 
     @OneToOne(mappedBy = "orderItem", cascade = CascadeType.ALL)
     private OrderCancel orderCancel;
 
     @OneToOne(mappedBy = "orderItem", cascade = CascadeType.ALL)
     private Review review;
+
+    public void setOrders(Orders orders) {
+        if (this.orders != null) {
+            this.orders.getOrderItemList().remove(this);
+        }
+        this.orders = orders;
+        orders.getOrderItemList().add(this);
+    }
+
+    public void setItem(Item item) {
+        if (this.item != null) {
+            this.item.getOrderItemList().remove(this);
+        }
+        this.item = item;
+        item.getOrderItemList().add(this);
+    }
+
+    // 주문 상품 합산 금액 업데이트 메소트
+    public void updateTotalPrice(Long price) {
+        this.totalPrice += price;
+    }
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/Orders.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/Orders.java
@@ -27,33 +27,16 @@ public class Orders extends BaseDateTimeEntity {
     @Column(nullable = false, length = 20)
     private String phone;
 
-    @Column(nullable = false, length = 10)
-    private String zipcode;
-
-    @Column(nullable = false, length = 300)
-    private String address;
-
-    private String addressDetail;
-
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     private PayType payType;
-
-    @Column(nullable = false, length = 30)
-    private String refundBank;
-
-    @Column(nullable = false, length = 30)
-    private String refundAccount;
-
-    @Column(nullable = false, length = 20)
-    private String refundOwner;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @OneToMany(mappedBy = "orders", cascade = CascadeType.ALL)
-    private List<OrderDetail> orderDetailList = new ArrayList<>();
+    private List<OrderItem> orderItemList = new ArrayList<>();
 
     // 연관관계 메소드
     public void setMember(Member member) {

--- a/src/main/java/com/umc/TheGoods/repository/order/OrderItemRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/order/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.umc.TheGoods.repository.order;
+
+import com.umc.TheGoods.domain.order.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/com/umc/TheGoods/service/CategoryService/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CategoryService/CategoryQueryServiceImpl.java
@@ -3,7 +3,7 @@ package com.umc.TheGoods.service.CategoryService;
 import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
 import com.umc.TheGoods.apiPayload.exception.handler.CategoryHandler;
 import com.umc.TheGoods.domain.item.Category;
-import com.umc.TheGoods.repository.CategoryRepository;
+import com.umc.TheGoods.repository.member.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class CategoryQueryServiceImpl implements CategoryQueryService{
+public class CategoryQueryServiceImpl implements CategoryQueryService {
 
     private final CategoryRepository categoryRepository;
 

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberQueryService.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberQueryService.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface MemberQueryService {
     Optional<Member> findMemberById(Long id);
+
+    Optional<Member> findMemberByNickname(String name);
 }

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberQueryServiceImpl.java
@@ -18,4 +18,10 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     public Optional<Member> findMemberById(Long id) {
         return memberRepository.findById(id);
     }
+
+    @Override
+    public Optional<Member> findMemberByNickname(String name) {
+        return memberRepository.findByNickname(name);
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -86,7 +86,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 
                     // item의 판매량, 재고 업데이트
                     item.updateSales(orderDetail.getAmount());
-                    item.updateSales(-orderDetail.getAmount());
+                    item.updateStock(-orderDetail.getAmount());
 
                     // OrderItem 주문 상품 합산 금액 업데이트
                     orderItem.updateTotalPrice(orderDetail.getOrderPrice());

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -7,10 +7,11 @@ import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.OrderDetail;
+import com.umc.TheGoods.domain.order.OrderItem;
 import com.umc.TheGoods.domain.order.Orders;
-import com.umc.TheGoods.repository.MemberRepository;
 import com.umc.TheGoods.repository.item.ItemOptionRepository;
 import com.umc.TheGoods.repository.item.ItemRepository;
+import com.umc.TheGoods.repository.order.OrderItemRepository;
 import com.umc.TheGoods.repository.order.OrderRepository;
 import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class OrderCommandServiceImpl implements OrderCommandService {
 
-    private final MemberRepository memberRepository;
     private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
     private final ItemRepository itemRepository;
     private final ItemOptionRepository itemOptionRepository;
 
@@ -35,64 +36,65 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         request.getOrderItemDtoList().forEach(orderItemDto -> {
             Item item = itemRepository.findById(orderItemDto.getItemId()).get();
 
-            Integer stock;
-
-            if (item.getPrice() == null) { // 옵션이 있는 상품인 경우
-                ItemOption itemOption = itemOptionRepository.findById(orderItemDto.getItemOptionId()).get();
-                stock = itemOption.getStock();
-            } else { // 단일 상품인 경우
-                stock = item.getStock();
-            }
-
-            if (orderItemDto.getAmount() > stock) { // 재고보다 주문 수량이 많은 경우
-                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
-            }
+            orderItemDto.getOrderDetailDTOList().forEach(orderDetailDTO -> {
+                if (orderDetailDTO.getItemOptionId() != null) { // 옵션이 있는 상품인 경우
+                    ItemOption itemOption = itemOptionRepository.findById(orderDetailDTO.getItemOptionId()).get();
+                    if (orderDetailDTO.getAmount() > itemOption.getStock()) { // 재고보다 주문 수량이 많은 경우
+                        throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+                    }
+                } else { // 단일 상품인 경우
+                    if (orderDetailDTO.getAmount() > item.getStock()) {
+                        throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+                    }
+                }
+            });
         });
 
         // Orders 엔티티 생성 및 연관관계 매핑
         Orders newOrders = OrderConverter.toOrders(request);
         newOrders.setMember(member);
-        Orders savedOrders = orderRepository.save(newOrders);
+        Orders orders = orderRepository.save(newOrders);
 
-        // orderDetail 엔티티 생성 및 연관관계 매핑, 상품 재고 및 판매수 업데이트
+        // OrderItem, OrderDetail 엔티티 생성, 연관관계 매핑, 판매 재고 업데이트
         request.getOrderItemDtoList().forEach(orderItemDto -> {
-
-            Long price;
-            ItemOption itemOption = null;
-
             Item item = itemRepository.findById(orderItemDto.getItemId()).get();
 
-            // 해당 상품의 옵션 유무 판별
-            boolean haveOption = (item.getPrice() == null);
+            // OrderItem 엔티티 생성 및 연관관계 매핑
+            OrderItem newOrderItem = OrderConverter.toOrderItem(request, item.getDeliveryFee());
+            newOrderItem.setItem(item);
+            newOrderItem.setOrders(orders);
+            OrderItem orderItem = orderItemRepository.save(newOrderItem);
 
-            if (haveOption) { // 상품 옵션이 존재하는 경우
-                itemOption = itemOptionRepository.findById(orderItemDto.getItemOptionId()).get();
-                price = itemOption.getPrice();
-            } else { // 단일 상품인 경우
-                price = item.getPrice();
-            }
-            // 엔티티 생성
-            OrderDetail orderDetail = OrderConverter.toOrderDetail(orderItemDto, price);
+            orderItemDto.getOrderDetailDTOList().forEach(orderDetailDTO -> {
+                if (orderDetailDTO.getItemOptionId() != null) { // 옵션이 있는 상품인 경우
+                    ItemOption itemOption = itemOptionRepository.findById(orderDetailDTO.getItemOptionId()).get();
 
-            // 양방향 연관관계 매핑
-            orderDetail.setOrders(savedOrders);
-            orderDetail.setItem(item);
-            if (haveOption) { // 상품 옵션이 존재하는 경우
-                orderDetail.setItemOption(itemOption);
-            }
+                    // OrderDetail 엔티티 생성
+                    OrderDetail orderDetail = OrderConverter.toOrderDetail(orderDetailDTO, itemOption.getPrice());
+                    orderDetail.setOrderItem(orderItem);
+                    orderDetail.setItemOption(itemOption);
 
-            // Item, ItemOption 엔티티의 재고 및 판매수 업데이트
-            Integer amount = orderItemDto.getAmount();
-            item.updateSales(amount);
+                    // item, itemOption의 판매량, 재고 업데이트
+                    item.updateSales(orderDetail.getAmount());
+                    itemOption.updateStock(-orderDetail.getAmount());
 
-            if (haveOption) {
-                itemOption.updateStock(-amount);
-            } else {
-                item.updateStock(-amount);
-            }
+                    // OrderItem 주문 상품 합산 금액 업데이트
+                    orderItem.updateTotalPrice(orderDetail.getOrderPrice());
+                } else {
+                    OrderDetail orderDetail = OrderConverter.toOrderDetail(orderDetailDTO, item.getPrice());
+                    orderDetail.setOrderItem(orderItem);
+
+                    // item의 판매량, 재고 업데이트
+                    item.updateSales(orderDetail.getAmount());
+                    item.updateSales(-orderDetail.getAmount());
+
+                    // OrderItem 주문 상품 합산 금액 업데이트
+                    orderItem.updateTotalPrice(orderDetail.getOrderPrice());
+                }
+            });
         });
 
-        return savedOrders;
+        return orders;
     }
 }
 

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -92,6 +92,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                     orderItem.updateTotalPrice(orderDetail.getOrderPrice());
                 }
             });
+            orderItem.updateTotalPrice(Long.valueOf(item.getDeliveryFee()));
         });
 
         return orders;

--- a/src/main/java/com/umc/TheGoods/validation/validator/OrderAvailableValidator.java
+++ b/src/main/java/com/umc/TheGoods/validation/validator/OrderAvailableValidator.java
@@ -1,12 +1,17 @@
 package com.umc.TheGoods.validation.validator;
 
+import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
+import com.umc.TheGoods.domain.item.Item;
+import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.service.ItemService.ItemQueryService;
 import com.umc.TheGoods.validation.annotation.OrderAvailable;
+import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -21,44 +26,46 @@ public class OrderAvailableValidator implements ConstraintValidator<OrderAvailab
 
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
-//        if (value instanceof OrderRequestDTO.OrderItemDto) {
-//            OrderRequestDTO.OrderItemDto request = (OrderRequestDTO.OrderItemDto) value;
-//
-//            // item 존재 여부 검증
-//            Optional<Item> item = itemQueryService.findItemById(request.getItemId());
-//            if (item.isEmpty()) { // 상품이 존재하지 않는 경우
-//                context.disableDefaultConstraintViolation();
-//                context.buildConstraintViolationWithTemplate(ErrorStatus.ITEM_NOT_FOUND.getMessage()).addConstraintViolation();
-//                return false;
-//            }
-//
-//            if (request.getItemOptionId() != null) { // request에 itemOptionId 값이 있는 경우
-//                // itemOption 존재 여부 검증
-//                Optional<ItemOption> itemOption = itemQueryService.findItemOptionById(request.getItemOptionId());
-//                if (itemOption.isEmpty()) { // 상품 옵션이 존재하지 않는 경우
-//                    context.disableDefaultConstraintViolation();
-//                    context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_FOUND.getMessage()).addConstraintViolation();
-//                    return false;
-//                }
-//
-//                // itemOption이 해당 item의 옵션이 맞는지 검증
-//
-//                boolean isValid = itemOption.get().getItem().equals(item.get());
-//                if (!isValid) { // itemOption이 해당 상품의 옵션이 아닌 경우
-//                    context.disableDefaultConstraintViolation();
-//                    context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_MATCH.getMessage()).addConstraintViolation();
-//                    return false;
-//                }
-//            } else {  // request에 itemOptionId 값이 없는 경우
-//                // item이 단일 상품인지 검증
-//                if (item.get().getPrice() == null) { // item이 단일 상품이 아닌 경우
-//                    context.disableDefaultConstraintViolation();
-//                    context.buildConstraintViolationWithTemplate(ErrorStatus.NULL_ITEMOPTION_ERROR.getMessage()).addConstraintViolation();
-//                    return false;
-//                }
-//            }
-//        }
+        if (value instanceof OrderRequestDTO.OrderItemDto) {
+            OrderRequestDTO.OrderItemDto orderItemDto = (OrderRequestDTO.OrderItemDto) value;
 
+            // item 존재 여부 검증
+            Optional<Item> item = itemQueryService.findItemById(orderItemDto.getItemId());
+            if (item.isEmpty()) { // 상품이 존재하지 않는 경우
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(ErrorStatus.ITEM_NOT_FOUND.getMessage()).addConstraintViolation();
+                return false;
+            }
+
+            // OrderDetailDTOList 돌면서 검증
+            for (OrderRequestDTO.OrderDetailDTO orderDetailDTO : orderItemDto.getOrderDetailDTOList()) {
+                if (orderDetailDTO.getItemOptionId() != null) { // request에 itemOptionId 값이 있는 경우
+                    // itemOption 존재 여부 검증
+                    Optional<ItemOption> itemOption = itemQueryService.findItemOptionById(orderDetailDTO.getItemOptionId());
+                    if (itemOption.isEmpty()) { // 해당 상품 옵션이 존재하지 않는 경우
+                        context.disableDefaultConstraintViolation();
+                        context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_FOUND.getMessage()).addConstraintViolation();
+                        return false;
+                    }
+
+                    // itemOption이 해당 item의 옵션이 맞는지 검증
+                    boolean isValid = itemOption.get().getItem().equals(item.get());
+                    if (!isValid) { // itemOption이 해당 상품의 옵션이 아닌 경우
+                        context.disableDefaultConstraintViolation();
+                        context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_MATCH.getMessage()).addConstraintViolation();
+                        return false;
+                    }
+
+                } else { // request에 itemOptionId 값이 없는 경우
+                    //item이 단일 상품인지 검증
+                    if (item.get().getPrice() == null) { // item이 단일 상품이 아닌 경우
+                        context.disableDefaultConstraintViolation();
+                        context.buildConstraintViolationWithTemplate(ErrorStatus.NULL_ITEMOPTION_ERROR.getMessage()).addConstraintViolation();
+                        return false;
+                    }
+                }
+            }
+        }
         return true;
     }
 }

--- a/src/main/java/com/umc/TheGoods/validation/validator/OrderAvailableValidator.java
+++ b/src/main/java/com/umc/TheGoods/validation/validator/OrderAvailableValidator.java
@@ -1,17 +1,12 @@
 package com.umc.TheGoods.validation.validator;
 
-import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
-import com.umc.TheGoods.domain.item.Item;
-import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.service.ItemService.ItemQueryService;
 import com.umc.TheGoods.validation.annotation.OrderAvailable;
-import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -26,43 +21,43 @@ public class OrderAvailableValidator implements ConstraintValidator<OrderAvailab
 
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
-        if (value instanceof OrderRequestDTO.OrderItemDto) {
-            OrderRequestDTO.OrderItemDto request = (OrderRequestDTO.OrderItemDto) value;
-
-            // item 존재 여부 검증
-            Optional<Item> item = itemQueryService.findItemById(request.getItemId());
-            if (item.isEmpty()) { // 상품이 존재하지 않는 경우
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(ErrorStatus.ITEM_NOT_FOUND.getMessage()).addConstraintViolation();
-                return false;
-            }
-
-            if (request.getItemOptionId() != null) { // request에 itemOptionId 값이 있는 경우
-                // itemOption 존재 여부 검증
-                Optional<ItemOption> itemOption = itemQueryService.findItemOptionById(request.getItemOptionId());
-                if (itemOption.isEmpty()) { // 상품 옵션이 존재하지 않는 경우
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_FOUND.getMessage()).addConstraintViolation();
-                    return false;
-                }
-
-                // itemOption이 해당 item의 옵션이 맞는지 검증
-
-                boolean isValid = itemOption.get().getItem().equals(item.get());
-                if (!isValid) { // itemOption이 해당 상품의 옵션이 아닌 경우
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_MATCH.getMessage()).addConstraintViolation();
-                    return false;
-                }
-            } else {  // request에 itemOptionId 값이 없는 경우
-                // item이 단일 상품인지 검증
-                if (item.get().getPrice() == null) { // item이 단일 상품이 아닌 경우
-                    context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate(ErrorStatus.NULL_ITEMOPTION_ERROR.getMessage()).addConstraintViolation();
-                    return false;
-                }
-            }
-        }
+//        if (value instanceof OrderRequestDTO.OrderItemDto) {
+//            OrderRequestDTO.OrderItemDto request = (OrderRequestDTO.OrderItemDto) value;
+//
+//            // item 존재 여부 검증
+//            Optional<Item> item = itemQueryService.findItemById(request.getItemId());
+//            if (item.isEmpty()) { // 상품이 존재하지 않는 경우
+//                context.disableDefaultConstraintViolation();
+//                context.buildConstraintViolationWithTemplate(ErrorStatus.ITEM_NOT_FOUND.getMessage()).addConstraintViolation();
+//                return false;
+//            }
+//
+//            if (request.getItemOptionId() != null) { // request에 itemOptionId 값이 있는 경우
+//                // itemOption 존재 여부 검증
+//                Optional<ItemOption> itemOption = itemQueryService.findItemOptionById(request.getItemOptionId());
+//                if (itemOption.isEmpty()) { // 상품 옵션이 존재하지 않는 경우
+//                    context.disableDefaultConstraintViolation();
+//                    context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_FOUND.getMessage()).addConstraintViolation();
+//                    return false;
+//                }
+//
+//                // itemOption이 해당 item의 옵션이 맞는지 검증
+//
+//                boolean isValid = itemOption.get().getItem().equals(item.get());
+//                if (!isValid) { // itemOption이 해당 상품의 옵션이 아닌 경우
+//                    context.disableDefaultConstraintViolation();
+//                    context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_MATCH.getMessage()).addConstraintViolation();
+//                    return false;
+//                }
+//            } else {  // request에 itemOptionId 값이 없는 경우
+//                // item이 단일 상품인지 검증
+//                if (item.get().getPrice() == null) { // item이 단일 상품이 아닌 경우
+//                    context.disableDefaultConstraintViolation();
+//                    context.buildConstraintViolationWithTemplate(ErrorStatus.NULL_ITEMOPTION_ERROR.getMessage()).addConstraintViolation();
+//                    return false;
+//                }
+//            }
+//        }
 
         return true;
     }

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.umc.TheGoods.web.controller;
 import com.umc.TheGoods.apiPayload.ApiResponse;
 import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
 import com.umc.TheGoods.apiPayload.exception.handler.MemberHandler;
+import com.umc.TheGoods.apiPayload.exception.handler.OrderHandler;
 import com.umc.TheGoods.converter.order.OrderConverter;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.Orders;
@@ -35,7 +36,9 @@ public class OrderController {
     private final MemberQueryService memberQueryService;
 
     @PostMapping
-    @Operation(summary = "주문 등록 API", description = "상품에 대한 주문을 등록하는 API 입니다.")
+    @Operation(summary = "주문 등록 API", description = "상품에 대한 주문을 등록하는 API 입니다.\n\n" +
+            "payType(결제 유형)은 \"ACCOUNT\" 또는 \"CARD\"로 입력해야 합니다.\n\n" +
+            "orderDetailDTOList 내부의 JSON에는 itemOptionId(상품 옵션 id)와 amount(주문 수량)을 담아주세요. 해당 상품이 단일 상품이라면 itemOptionId 값은 보내지 않아도 됩니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
@@ -44,7 +47,7 @@ public class OrderController {
 
         // 비로그인 요청인 경우 비회원 계정 불러오기
         if (authentication == null) {
-            member = memberQueryService.findMemberByNickname("no_login_user").get();
+            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
         } else {
             // request에서 member id 추출해 Member 엔티티 찾기
             MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -40,9 +40,16 @@ public class OrderController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     public ApiResponse<OrderResponseDTO.OrderAddResultDto> order(@RequestBody @Valid OrderRequestDTO.OrderAddDto request, Authentication authentication) {
-        // request에서 member id 추출해 Member 엔티티 찾기
-        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
-        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = null;
+
+        // 비로그인 요청인 경우 비회원 계정 불러오기
+        if (authentication == null) {
+            member = memberQueryService.findMemberByNickname("no_login_user").get();
+        } else {
+            // request에서 member id 추출해 Member 엔티티 찾기
+            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
 
         Orders orders = orderCommandService.create(request, member);
 

--- a/src/main/java/com/umc/TheGoods/web/controller/TestController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/TestController.java
@@ -38,7 +38,11 @@ public class TestController {
     @Operation(summary = "테스트용 데이터 생성 API", description = "회원, 상품, 상품 옵션 dummy data를 생성해 db에 저장합니다. category, term, tag 데이터는 db에 수동으로 입력해야 합니다. (id가 1인 category, term, tag 데이터가 필요합니다.) \n\n " +
             "category 생성 sql: INSERT INTO category(name,created_at,updated_at) VALUES ('아이돌',now(),now());\n\n" +
             "tag 생성 sql: INSERT INTO tag(name,created_at,updated_at) VALUES ('포카',now(),now());\n\n" +
-            "term 생성 sql: INSERT INTO term(title,created_at,updated_at) VALUES ('정보 이용 동의',now(),now());")
+            "term 생성 sql: INSERT INTO term(title,created_at,updated_at) VALUES ('정보 이용 동의',now(),now());\n\n" +
+            "생성된 회원 계정은 아래와 같습니다.\n\n" +
+            "1. 구매자 계정 - email: testbuyer@gmail.com, password: 12345678\n\n" +
+            "2. 판매자 계정 - email: testseller@gmail.com, password: 12345678\n\n" +
+            "3. 비로그인 주문용 계정 - email: nologinuser@gmail.com, password:12345678")
     public String setTestData() {
 
         // 회원 가입
@@ -50,9 +54,12 @@ public class TestController {
 
         MemberRequestDTO.JoinDTO joinBuyerDTO = new MemberRequestDTO.JoinDTO("test_buyer", "12345678", "testbuyer@gmail.com", date, "01012345678", Gender.MALE, termAgreeList, memberCategoryList);
         MemberRequestDTO.JoinDTO joinSellerDTO = new MemberRequestDTO.JoinDTO("test_seller", "12345678", "testseller@gmail.com", date, "01012341234", Gender.MALE, termAgreeList, memberCategoryList);
+        MemberRequestDTO.JoinDTO noLoginUserDTO = new MemberRequestDTO.JoinDTO("no_login_user", "12345678", "nologinuser@gmail.com", date, "01087654321", Gender.MALE, termAgreeList, memberCategoryList);
+
 
         memberCommandService.join(joinBuyerDTO);
         memberCommandService.join(joinSellerDTO);
+        memberCommandService.join(noLoginUserDTO);
 
         // item 및 itemOption 등록
         Member member = memberQueryService.findMemberById(2L).get();

--- a/src/main/java/com/umc/TheGoods/web/controller/TestController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/TestController.java
@@ -1,17 +1,98 @@
 package com.umc.TheGoods.web.controller;
 
+import com.umc.TheGoods.domain.enums.Gender;
+import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.service.ItemService.ItemCommandService;
+import com.umc.TheGoods.service.MemberService.MemberCommandServiceImpl;
+import com.umc.TheGoods.service.MemberService.MemberQueryService;
+import com.umc.TheGoods.web.dto.item.ItemRequestDTO;
+import com.umc.TheGoods.web.dto.member.MemberRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("api")
 public class TestController {
+
+    private final MemberCommandServiceImpl memberCommandService;
+    private final MemberQueryService memberQueryService;
+    private final ItemCommandService itemCommandService;
+
 
     @GetMapping("/test/hello")
     @Operation(summary = "Return hello", description = "simple API for swagger test!")
     public String hello() {
         return "Hello, Swagger!";
+    }
+
+    @GetMapping("/setTestData")
+    @Operation(summary = "테스트용 데이터 생성 API", description = "회원, 상품, 상품 옵션 dummy data를 생성해 db에 저장합니다. category, term, tag 데이터는 db에 수동으로 입력해야 합니다. (id가 1인 category, term, tag 데이터가 필요합니다.) \n\n " +
+            "category 생성 sql: INSERT INTO category(name,created_at,updated_at) VALUES ('아이돌',now(),now());\n\n" +
+            "tag 생성 sql: INSERT INTO tag(name,created_at,updated_at) VALUES ('포카',now(),now());\n\n" +
+            "term 생성 sql: INSERT INTO term(title,created_at,updated_at) VALUES ('정보 이용 동의',now(),now());")
+    public String setTestData() {
+
+        // 회원 가입
+        Date date = new Date();
+        List<Boolean> termAgreeList = new ArrayList<>();
+        termAgreeList.add(true);
+        List<Long> memberCategoryList = new ArrayList<>();
+        memberCategoryList.add(1L);
+
+        MemberRequestDTO.JoinDTO joinBuyerDTO = new MemberRequestDTO.JoinDTO("test_buyer", "12345678", "testbuyer@gmail.com", date, "01012345678", Gender.MALE, termAgreeList, memberCategoryList);
+        MemberRequestDTO.JoinDTO joinSellerDTO = new MemberRequestDTO.JoinDTO("test_seller", "12345678", "testseller@gmail.com", date, "01012341234", Gender.MALE, termAgreeList, memberCategoryList);
+
+        memberCommandService.join(joinBuyerDTO);
+        memberCommandService.join(joinSellerDTO);
+
+        // item 및 itemOption 등록
+        Member member = memberQueryService.findMemberById(2L).get();
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = LocalDate.of(2024, 3, 1);
+
+        ItemRequestDTO.itemImgDTO itemImgDTO = new ItemRequestDTO.itemImgDTO(false, "img url");
+        List<ItemRequestDTO.itemImgDTO> itemImgDTOList = new ArrayList<>();
+        itemImgDTOList.add(itemImgDTO);
+
+        List<Long> tagList = new ArrayList<>();
+        tagList.add(1L);
+
+        // 뉴진스 포카 item 등록
+        ItemRequestDTO.itemOptionDTO itemOptionDTO1 = new ItemRequestDTO.itemOptionDTO("해린 포카", 1000L, 20);
+        ItemRequestDTO.itemOptionDTO itemOptionDTO2 = new ItemRequestDTO.itemOptionDTO("민지 포카", 2000L, 20);
+        ItemRequestDTO.itemOptionDTO itemOptionDTO3 = new ItemRequestDTO.itemOptionDTO("하니 포카", 3000L, 20);
+        List<ItemRequestDTO.itemOptionDTO> itemOptionDTOList1 = new ArrayList<>();
+        itemOptionDTOList1.add(itemOptionDTO1);
+        itemOptionDTOList1.add(itemOptionDTO2);
+        itemOptionDTOList1.add(itemOptionDTO3);
+
+        ItemRequestDTO.UploadItemDTO uploadItemDTO1 = new ItemRequestDTO.UploadItemDTO("뉴진스 포카", "ONSALE", null, null, 3000, 1, 3, "뉴진스 포카입니다.", false, startDate, endDate, 0L, 0L, 0L, 1L, itemImgDTOList, itemOptionDTOList1, tagList);
+        itemCommandService.uploadItem(member, uploadItemDTO1);
+
+        // 아이브 포카 item 등록
+        ItemRequestDTO.itemOptionDTO itemOptionDTO4 = new ItemRequestDTO.itemOptionDTO("원영 포카", 1000L, 20);
+        ItemRequestDTO.itemOptionDTO itemOptionDTO5 = new ItemRequestDTO.itemOptionDTO("유진 포카", 2000L, 20);
+        List<ItemRequestDTO.itemOptionDTO> itemOptionDTOList2 = new ArrayList<>();
+        itemOptionDTOList2.add(itemOptionDTO4);
+        itemOptionDTOList2.add(itemOptionDTO5);
+
+        ItemRequestDTO.UploadItemDTO uploadItemDTO2 = new ItemRequestDTO.UploadItemDTO("아이브 포카", "ONSALE", null, null, 2000, 1, 3, "아이브 포카입니다.", false, startDate, endDate, 0L, 0L, 0L, 1L, itemImgDTOList, itemOptionDTOList2, tagList);
+        itemCommandService.uploadItem(member, uploadItemDTO2);
+
+        // 카리나 포카 item 등록 (단일 상품)
+        ItemRequestDTO.UploadItemDTO uploadItemDTO3 = new ItemRequestDTO.UploadItemDTO("카리나 포카", "ONSALE", 100, 3000L, 3000, 1, 3, "카리나 포카입니다.", false, startDate, endDate, 0L, 0L, 0L, 1L, itemImgDTOList, new ArrayList<>(), tagList);
+        itemCommandService.uploadItem(member, uploadItemDTO3);
+
+
+        return "Setting Test Data";
     }
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/item/ItemRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/item/ItemRequestDTO.java
@@ -1,6 +1,7 @@
 package com.umc.TheGoods.web.dto.item;
 
 import com.umc.TheGoods.validation.annotation.ExistTag;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.lang.Nullable;
 
@@ -12,6 +13,7 @@ import java.util.List;
 public class ItemRequestDTO {
 
     @Getter
+    @AllArgsConstructor
     public static class UploadItemDTO {
         @NotBlank
         String name;
@@ -53,6 +55,7 @@ public class ItemRequestDTO {
     }
 
     @Getter
+    @AllArgsConstructor
     public static class itemImgDTO {
         @Nullable
         Boolean isThumbnail;
@@ -61,6 +64,7 @@ public class ItemRequestDTO {
     }
 
     @Getter
+    @AllArgsConstructor
     public static class itemOptionDTO {
         @NotNull
         String name;

--- a/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
@@ -1,5 +1,6 @@
 package com.umc.TheGoods.web.dto.order;
 
+import com.umc.TheGoods.validation.annotation.OrderAvailable;
 import lombok.Getter;
 
 import javax.validation.Valid;
@@ -46,7 +47,7 @@ public class OrderRequestDTO {
     }
 
     @Getter
-    //@OrderAvailable
+    @OrderAvailable
     public static class OrderItemDto {
         @NotNull
         Long itemId;

--- a/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
@@ -1,6 +1,5 @@
 package com.umc.TheGoods.web.dto.order;
 
-import com.umc.TheGoods.validation.annotation.OrderAvailable;
 import lombok.Getter;
 
 import javax.validation.Valid;
@@ -25,6 +24,8 @@ public class OrderRequestDTO {
 
         String addressDetail;
 
+        String deliveryMemo;
+
         @NotBlank
         String payType;
 
@@ -37,18 +38,25 @@ public class OrderRequestDTO {
         @NotBlank
         String refundOwner;
 
+        String depositor;
+
         @NotEmpty
         @Valid
         List<OrderItemDto> orderItemDtoList;
     }
 
     @Getter
-    @OrderAvailable
+    //@OrderAvailable
     public static class OrderItemDto {
-
         @NotNull
         Long itemId;
 
+        @NotEmpty
+        List<OrderDetailDTO> orderDetailDTOList;
+    }
+
+    @Getter
+    public static class OrderDetailDTO {
         Long itemOptionId;
 
         @Min(1)


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
주문 내역 조회 페이지에서 관리되는 주문 내역의 단위가 "주문한 상품 옵션" 단위에서 "주문한 상품" 단위로 변경됨에 따라 주문 도메인 및 주문 등록 API를 수정했습니다. 비회원 주문을 등록하는 기능이 추가되었습니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Entity 설정 변경으로 인해 ddl-auto:create로 실행 한 번 필요합니다.
- OrderItem entity가 추가됨에 따라 다른 주문 관련 entity도 변경되었습니다. 
- 주문 관련 converter, repository, service, converter, validator가 변경되었습니다.
- db에 회원, 상품, 상품 옵션 관련 dummy data를 추가해주는 테스트용 api가 추가되었습니다.

## ⏳ 작업 내용
- [x] 주문 도메인 수정
- [x] 주문 등록 API 수정
- [x] 비회원 주문 등록 기능 추가
- [x] 테스트용 api 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
작업 편의를 위해서 테스트용 데이터 세팅 api를 만들었습니다..
ddl-auto:create를 하면 기존에 테스트하던 데이터들이 모두 사라지는데, 이 때 회원, 상품, 상품 옵션 관련 dummy data를 추가해주는 api를 사용해 테스트 데이터를 세팅할 수 있습니다.
GET /api/setTestData를 실행하면 3개의 회원 계정이 생성 되고, 상품 데이터 3개와 상품 옵션 데이터 5개가 생성됩니다.
Swagger에 해당 api 명세를 참고해주시고 이해가 안되신다면 따로 질문 부탁드려요..!

