### PR TITLE
:sparkles: Feat: 아이디 찾기, 비밀번호 찾기 API

### DIFF
--- a/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
@@ -78,6 +78,7 @@ public class MemberConverter {
         return PhoneAuth.builder()
                 .phone(phone)
                 .code(code)
+                .expireDate(LocalDateTime.now().plusMinutes(5))
                 .expired(expired)
                 .build();
     }
@@ -104,6 +105,13 @@ public class MemberConverter {
     public static MemberResponseDTO.NicknameDuplicateConfirmResultDTO toNicknameDuplicateConfirmResultDTO(Boolean checkNickname) {
         return MemberResponseDTO.NicknameDuplicateConfirmResultDTO.builder()
                 .checkNickname(checkNickname)
+                .build();
+    }
+
+
+    public static MemberResponseDTO.PhoneAuthConfirmFindEmailResultDTO toPhoneAuthConfirmFindEmailDTO(String email) {
+        return MemberResponseDTO.PhoneAuthConfirmFindEmailResultDTO.builder()
+                .email(email)
                 .build();
     }
 }

--- a/src/main/java/com/umc/TheGoods/domain/member/PhoneAuth.java
+++ b/src/main/java/com/umc/TheGoods/domain/member/PhoneAuth.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/umc/TheGoods/repository/member/MemberRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/member/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByPhone(String phone);
 }

--- a/src/main/java/com/umc/TheGoods/repository/member/PhoneAuthRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/member/PhoneAuthRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface PhoneAuthRepository extends JpaRepository<PhoneAuth, Long> {
     Optional<PhoneAuth> findByPhone(String phone);
+
+    
 }

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
@@ -23,5 +23,7 @@ public interface MemberCommandService {
 
     Boolean confirmNicknameDuplicate(MemberRequestDTO.NicknameDuplicateConfirmDTO request);
 
+    String confirmPhoneAuthFindEmail(MemberRequestDTO.PhoneAuthConfirmFindEmailDTO request);
+
 
 }

--- a/src/main/java/com/umc/TheGoods/web/controller/MemberController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/MemberController.java
@@ -104,4 +104,12 @@ public class MemberController {
 
         return ApiResponse.onSuccess(MemberConverter.toNicknameDuplicateConfirmResultDTO(checkNickname));
     }
+
+    @PostMapping("phone/auth/verify/find/email")
+    @Operation(summary = "이메일 찾기에서 사용되는 번호 확인 api", description = "request: 인증 코드, response: 인증 완료 되면 email")
+    public ApiResponse<MemberResponseDTO.PhoneAuthConfirmFindEmailResultDTO> phoneAuthFindEmail(@RequestBody MemberRequestDTO.PhoneAuthConfirmFindEmailDTO request) {
+        String email = memberCommandService.confirmPhoneAuthFindEmail(request);
+        
+        return ApiResponse.onSuccess(MemberConverter.toPhoneAuthConfirmFindEmailDTO(email));
+    }
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/MemberRequestDTO.java
@@ -66,4 +66,12 @@ public class MemberRequestDTO {
         private String nickname;
     }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PhoneAuthConfirmFindEmailDTO {
+        private String phone;
+        private String code;
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
@@ -64,4 +64,12 @@ public class MemberResponseDTO {
         Boolean checkNickname;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PhoneAuthConfirmFindEmailResultDTO {
+        String email;
+    }
+
 }


### PR DESCRIPTION
# 🚀 개요
아이디 찾기, 비밀번호 찾기 API

## 🔍 변경사항

- PhoneAuth Entity @Setter annotation 추가
- 전화번호 인증시 이전에 사용했던 전화번호가 PhoneAuth db에 담겨 있으면 삭제하고 새로 저장


## ⏳ 작업 내용
- [x] 아이디 찾기
- [x] 비밀 번호 찾기


### 📝 논의사항
PhoneAuth Entity에 @Setter를 사용해서 expired값을 변경하는데 사용했는데 보통 setter를 사용하지 않는 것을 권장했던거 같은데 api 중간에 값을 변경하는 방법을 모르겠어서 일단 setter를 이용해서 구현했습니다.

