### PR TITLE
[feature/40] 주문 구매 확정 API 구현

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4005", "해당 주문 상품 내역을 찾을 수 없습니다."),
     NOT_ORDER_OWNER(HttpStatus.BAD_REQUEST, "ORDER4006", "본인의 주문 내역이 아닙니다. 접근할 수 없습니다."),
     NO_LOGIN_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4007", "비회원 주문 내역을 찾을 수 없습니다"),
+    UPDATE_ORDER_STATUS_FAIL(HttpStatus.BAD_REQUEST, "ORDER4008", "주문 내역 상태 변경이 불가합니다."),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),

--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -29,7 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4005", "해당 주문 상품 내역을 찾을 수 없습니다."),
     NOT_ORDER_OWNER(HttpStatus.BAD_REQUEST, "ORDER4006", "본인의 주문 내역이 아닙니다. 접근할 수 없습니다."),
     NO_LOGIN_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4007", "비회원 주문 내역을 찾을 수 없습니다"),
-    UPDATE_ORDER_STATUS_FAIL(HttpStatus.BAD_REQUEST, "ORDER4008", "주문 내역 상태 변경이 불가합니다."),
+    ORDER_ITEM_UPDATE_FAIL(HttpStatus.BAD_REQUEST, "ORDER4008", "주문 상품 정보 변경이 불가합니다."),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),

--- a/src/main/java/com/umc/TheGoods/converter/order/OrderConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/order/OrderConverter.java
@@ -9,7 +9,6 @@ import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import com.umc.TheGoods.web.dto.order.OrderResponseDTO;
 import org.springframework.data.domain.Page;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,7 +19,7 @@ public class OrderConverter {
     public static OrderResponseDTO.OrderAddResultDTO toOrderAddResultDto(Orders order) {
         return OrderResponseDTO.OrderAddResultDTO.builder()
                 .orderId(order.getId())
-                .createdAt(LocalDateTime.now())
+                .createdAt(order.getCreatedAt())
                 .build();
     }
 
@@ -193,5 +192,12 @@ public class OrderConverter {
         }
 
         return itemOptionName;
+    }
+
+    public static OrderResponseDTO.OrderItemUpdateResultDTO toOrderItemUpdateResultDto(OrderItem orderItem) {
+        return OrderResponseDTO.OrderItemUpdateResultDTO.builder()
+                .orderItemId(orderItem.getId())
+                .updatedAt(orderItem.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
@@ -5,7 +5,6 @@ import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.Review;
 import com.umc.TheGoods.domain.types.DeliveryType;
-import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -109,27 +108,6 @@ public class OrderItem extends BaseDateTimeEntity {
     // 주문 상품 합산 금액 업데이트 메소트
     public void updateTotalPrice(Long price) {
         this.totalPrice += price;
-    }
-
-    // 배송지 정보 업데이트 메소드
-    public OrderItem updateAddressInfo(OrderRequestDTO.OrderItemAddressUpdateDTO request) {
-        this.receiverName = request.getReceiverName();
-        this.receiverPhone = request.getReceiverPhone();
-        this.zipcode = request.getZipcode();
-        this.address = request.getAddress();
-        this.addressDetail = request.getAddressDetail();
-        this.deliveryMemo = request.getDeliveryMemo();
-
-        return this;
-    }
-
-    // 환불 계좌 정보 업데이트 메소드
-    public OrderItem updateRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request) {
-        this.refundOwner = request.getRefundOwner();
-        this.refundBank = request.getRefundBank();
-        this.refundAccount = request.getRefundAccount();
-
-        return this;
     }
 
     // 주문 상태 업데이트 메소드

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
@@ -109,4 +109,10 @@ public class OrderItem extends BaseDateTimeEntity {
     public void updateTotalPrice(Long price) {
         this.totalPrice += price;
     }
+
+    // 주문 상태 업데이트 메소드
+    public OrderItem updateStatus(OrderStatus orderStatus) {
+        this.status = orderStatus;
+        return this;
+    }
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
@@ -5,6 +5,7 @@ import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.Review;
 import com.umc.TheGoods.domain.types.DeliveryType;
+import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -108,6 +109,27 @@ public class OrderItem extends BaseDateTimeEntity {
     // 주문 상품 합산 금액 업데이트 메소트
     public void updateTotalPrice(Long price) {
         this.totalPrice += price;
+    }
+
+    // 배송지 정보 업데이트 메소드
+    public OrderItem updateAddressInfo(OrderRequestDTO.OrderItemAddressUpdateDTO request) {
+        this.receiverName = request.getReceiverName();
+        this.receiverPhone = request.getReceiverPhone();
+        this.zipcode = request.getZipcode();
+        this.address = request.getAddress();
+        this.addressDetail = request.getAddressDetail();
+        this.deliveryMemo = request.getDeliveryMemo();
+
+        return this;
+    }
+
+    // 환불 계좌 정보 업데이트 메소드
+    public OrderItem updateRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request) {
+        this.refundOwner = request.getRefundOwner();
+        this.refundBank = request.getRefundBank();
+        this.refundAccount = request.getRefundAccount();
+
+        return this;
     }
 
     // 주문 상태 업데이트 메소드

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
@@ -8,10 +8,6 @@ import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 public interface OrderCommandService {
 
     Orders create(OrderRequestDTO.OrderAddDTO request, Member member);
-
-    OrderItem updateOrderItemAddress(OrderRequestDTO.OrderItemAddressUpdateDTO request, Long orderItemId, Member member);
-
-    OrderItem updateOrderItemRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request, Long orderItemId, Member member);
-
+    
     OrderItem updateStatusToConfirm(Long orderItemId, Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
@@ -1,10 +1,13 @@
 package com.umc.TheGoods.service.OrderService;
 
 import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.domain.order.OrderItem;
 import com.umc.TheGoods.domain.order.Orders;
 import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 
 public interface OrderCommandService {
 
-    public Orders create(OrderRequestDTO.OrderAddDTO request, Member member);
+    Orders create(OrderRequestDTO.OrderAddDTO request, Member member);
+
+    OrderItem updateStatusToConfirm(Long orderItemId, Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
@@ -9,5 +9,9 @@ public interface OrderCommandService {
 
     Orders create(OrderRequestDTO.OrderAddDTO request, Member member);
 
+    OrderItem updateOrderItemAddress(OrderRequestDTO.OrderItemAddressUpdateDTO request, Long orderItemId, Member member);
+
+    OrderItem updateOrderItemRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request, Long orderItemId, Member member);
+
     OrderItem updateStatusToConfirm(Long orderItemId, Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -100,6 +100,37 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     }
 
     @Override
+    public OrderItem updateOrderItemAddress(OrderRequestDTO.OrderItemAddressUpdateDTO request, Long orderItemId, Member member) {
+        OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
+
+        // member가 해당 orderItem에 수정 권한이 있는지 검증
+        if (!orderItem.getOrders().getMember().equals(member)) {
+            throw new OrderHandler(ErrorStatus.NOT_ORDER_OWNER);
+        }
+
+        // 해당 orderItem의 status가 배송 준비 이전인지 검증
+        if (!(orderItem.getStatus() == OrderStatus.PAY_PREV || orderItem.getStatus() == OrderStatus.PAY_COMP)) {
+            throw new OrderHandler(ErrorStatus.ORDER_ITEM_UPDATE_FAIL);
+        }
+
+        return orderItem.updateAddressInfo(request);
+    }
+
+    @Override
+    public OrderItem updateOrderItemRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request, Long orderItemId, Member member) {
+        OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
+
+        // member가 해당 orderItem에 수정 권한이 있는지 검증
+        if (!orderItem.getOrders().getMember().equals(member)) {
+            throw new OrderHandler(ErrorStatus.NOT_ORDER_OWNER);
+        }
+
+        // orderItem의 status가 환불 계좌 변경 가능한 단계인지 검증 필요
+
+        return orderItem.updateRefundInfo(request);
+    }
+
+    @Override
     public OrderItem updateStatusToConfirm(Long orderItemId, Member member) {
         OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
 

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -100,37 +100,6 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     }
 
     @Override
-    public OrderItem updateOrderItemAddress(OrderRequestDTO.OrderItemAddressUpdateDTO request, Long orderItemId, Member member) {
-        OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
-
-        // member가 해당 orderItem에 수정 권한이 있는지 검증
-        if (!orderItem.getOrders().getMember().equals(member)) {
-            throw new OrderHandler(ErrorStatus.NOT_ORDER_OWNER);
-        }
-
-        // 해당 orderItem의 status가 배송 준비 이전인지 검증
-        if (!(orderItem.getStatus() == OrderStatus.PAY_PREV || orderItem.getStatus() == OrderStatus.PAY_COMP)) {
-            throw new OrderHandler(ErrorStatus.ORDER_ITEM_UPDATE_FAIL);
-        }
-
-        return orderItem.updateAddressInfo(request);
-    }
-
-    @Override
-    public OrderItem updateOrderItemRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request, Long orderItemId, Member member) {
-        OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
-
-        // member가 해당 orderItem에 수정 권한이 있는지 검증
-        if (!orderItem.getOrders().getMember().equals(member)) {
-            throw new OrderHandler(ErrorStatus.NOT_ORDER_OWNER);
-        }
-
-        // orderItem의 status가 환불 계좌 변경 가능한 단계인지 검증 필요
-
-        return orderItem.updateRefundInfo(request);
-    }
-
-    @Override
     public OrderItem updateStatusToConfirm(Long orderItemId, Member member) {
         OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
 
@@ -141,7 +110,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
 
         // 해당 orderItem의 상태가 DEL_COMP인지 검증
         if (orderItem.getStatus() != OrderStatus.DEL_COMP) {
-            throw new OrderHandler(ErrorStatus.UPDATE_ORDER_STATUS_FAIL);
+            throw new OrderHandler(ErrorStatus.ORDER_ITEM_UPDATE_FAIL);
         }
 
         return orderItem.updateStatus(OrderStatus.CONFIRM);

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.TheGoods.service.OrderService;
 import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
 import com.umc.TheGoods.apiPayload.exception.handler.OrderHandler;
 import com.umc.TheGoods.converter.order.OrderConverter;
+import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.member.Member;
@@ -96,6 +97,23 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         });
 
         return orders;
+    }
+
+    @Override
+    public OrderItem updateStatusToConfirm(Long orderItemId, Member member) {
+        OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
+
+        // 해당 orderItem을 수정할 권한이 있는지 검증
+        if (!orderItem.getOrders().getMember().equals(member)) {
+            throw new OrderHandler(ErrorStatus.NOT_ORDER_OWNER);
+        }
+
+        // 해당 orderItem의 상태가 DEL_COMP인지 검증
+        if (orderItem.getStatus() != OrderStatus.DEL_COMP) {
+            throw new OrderHandler(ErrorStatus.UPDATE_ORDER_STATUS_FAIL);
+        }
+
+        return orderItem.updateStatus(OrderStatus.CONFIRM);
     }
 }
 

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderQueryServiceImpl.java
@@ -62,6 +62,7 @@ public class OrderQueryServiceImpl implements OrderQueryService {
 
         OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(() -> new OrderHandler(ErrorStatus.ORDER_ITEM_NOT_FOUND));
 
+        // 해당 orderItem을 조회할 권한이 있는지 검증
         if (!orderItem.getOrders().getMember().equals(member) && !orderItem.getItem().getMember().equals(member)) { // 해당 orderItem의 구매자 && 판매자가 아닌 경우
             log.info("orderItem.getOrders.getMember(): {}", orderItem.getOrders().getMember().getNickname());
             log.info("member parameter: {}", member.getNickname());

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -138,63 +138,14 @@ public class OrderController {
 
     }
 
-    @PutMapping("/{orderItemId}/info/address")
-    @Operation(summary = "주문 배송지 정보 수정 API", description = "상품 주문 내역의 배송지 정보를 변경하는 API 입니다.\n\n" +
-            "orderItemId(상품 주문 내역 id)와 배송지 정보를 보내주세요.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-    })
-    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
-    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> updateOrderItemAddress(
-            @RequestBody OrderRequestDTO.OrderItemAddressUpdateDTO request,
-            @PathVariable(name = "orderItemId") Long orderItemId,
-            Authentication authentication
-    ) {
-        Member member = null;
-
-        // 비로그인 요청인 경우 비회원 계정 불러오기
-        if (authentication == null) {
-            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
-        } else {
-            // request에서 member id 추출해 Member 엔티티 찾기
-            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
-            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        }
-
-        OrderItem orderItem = orderCommandService.updateOrderItemAddress(request, orderItemId, member);
-
-        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
-    }
-
-    @PutMapping("/{orderItemId}/info/refund")
-    @Operation(summary = "주문 환불 계좌 정보 수정 API", description = "상품 주문 내역의 환불 계좌 정보를 변경하는 API 입니다.\n\n" +
-            "orderItemId(상품 주문 내역 id)와 환불 계좌 정보를 보내주세요.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-    })
-    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
-    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> updateOrderItemRefundInfo(
-            @RequestBody OrderRequestDTO.OrderItemRefundInfoUpdateDTO request,
-            @PathVariable(name = "orderItemId") Long orderItemId,
-            Authentication authentication
-    ) {
-        Member member = null;
-
-        // 비로그인 요청인 경우 비회원 계정 불러오기
-        if (authentication == null) {
-            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
-        } else {
-            // request에서 member id 추출해 Member 엔티티 찾기
-            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
-            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        }
-
-        OrderItem orderItem = orderCommandService.updateOrderItemRefundInfo(request, orderItemId, member);
-
-        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
-    }
     @PostMapping("/{orderItemId}/complete")
-    public String orderPurchaseConfirm(
+    @Operation(summary = "주문 구매 확정 API", description = "주문을 구매 확정 처리하는 API 입니다.\n\n" +
+            "orderItemId(상품 주문 내역 id)를 입력해주세요.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
+    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> orderPurchaseConfirm(
             @PathVariable(name = "orderItemId") Long orderItemId,
             Authentication authentication
     ) {
@@ -207,7 +158,8 @@ public class OrderController {
         MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
         Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        orderCommandService.updateStatusToConfirm(orderItemId, member);
-        return "update succeed";
+        OrderItem orderItem = orderCommandService.updateStatusToConfirm(orderItemId, member);
+
+        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
     }
 }

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -82,6 +82,11 @@ public class OrderController {
             @RequestParam(name = "status", required = false) OrderStatus orderStatus,
             Authentication authentication
     ) {
+        // 비회원인 경우 처리 불가
+        if (authentication == null) {
+            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
+        }
+        
         // request에서 member id 추출해 Member 엔티티 찾기
         MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
         Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -133,4 +138,21 @@ public class OrderController {
 
     }
 
+    @PostMapping("/{orderItemId}/complete")
+    public String orderPurchaseConfirm(
+            @PathVariable(name = "orderItemId") Long orderItemId,
+            Authentication authentication
+    ) {
+        // 비회원인 경우 처리 불가
+        if (authentication == null) {
+            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        // request에서 member id 추출해 Member 엔티티 찾기
+        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        orderCommandService.updateStatusToConfirm(orderItemId, member);
+        return "update succeed";
+    }
 }

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -86,7 +86,7 @@ public class OrderController {
         if (authentication == null) {
             throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
         }
-        
+
         // request에서 member id 추출해 Member 엔티티 찾기
         MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
         Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -138,6 +138,61 @@ public class OrderController {
 
     }
 
+    @PutMapping("/{orderItemId}/info/address")
+    @Operation(summary = "주문 배송지 정보 수정 API", description = "상품 주문 내역의 배송지 정보를 변경하는 API 입니다.\n\n" +
+            "orderItemId(상품 주문 내역 id)와 배송지 정보를 보내주세요.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
+    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> updateOrderItemAddress(
+            @RequestBody OrderRequestDTO.OrderItemAddressUpdateDTO request,
+            @PathVariable(name = "orderItemId") Long orderItemId,
+            Authentication authentication
+    ) {
+        Member member = null;
+
+        // 비로그인 요청인 경우 비회원 계정 불러오기
+        if (authentication == null) {
+            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
+        } else {
+            // request에서 member id 추출해 Member 엔티티 찾기
+            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
+
+        OrderItem orderItem = orderCommandService.updateOrderItemAddress(request, orderItemId, member);
+
+        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
+    }
+
+    @PutMapping("/{orderItemId}/info/refund")
+    @Operation(summary = "주문 환불 계좌 정보 수정 API", description = "상품 주문 내역의 환불 계좌 정보를 변경하는 API 입니다.\n\n" +
+            "orderItemId(상품 주문 내역 id)와 환불 계좌 정보를 보내주세요.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
+    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> updateOrderItemRefundInfo(
+            @RequestBody OrderRequestDTO.OrderItemRefundInfoUpdateDTO request,
+            @PathVariable(name = "orderItemId") Long orderItemId,
+            Authentication authentication
+    ) {
+        Member member = null;
+
+        // 비로그인 요청인 경우 비회원 계정 불러오기
+        if (authentication == null) {
+            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
+        } else {
+            // request에서 member id 추출해 Member 엔티티 찾기
+            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
+
+        OrderItem orderItem = orderCommandService.updateOrderItemRefundInfo(request, orderItemId, member);
+
+        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
+    }
     @PostMapping("/{orderItemId}/complete")
     public String orderPurchaseConfirm(
             @PathVariable(name = "orderItemId") Long orderItemId,

--- a/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
@@ -84,4 +84,29 @@ public class OrderRequestDTO {
         @Min(1)
         Integer page;
     }
+
+    @Getter
+    public static class OrderItemAddressUpdateDTO {
+        @NotBlank
+        String receiverName;
+        @NotBlank
+        String receiverPhone;
+        @Size(min = 5, max = 6)
+        String zipcode;
+        @NotBlank
+        String address;
+        String addressDetail;
+        String deliveryMemo;
+    }
+
+    @Getter
+    public static class OrderItemRefundInfoUpdateDTO {
+        @NotBlank
+        String refundOwner;
+        @NotBlank
+        String refundBank;
+        @NotBlank
+        String refundAccount;
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
@@ -85,28 +85,4 @@ public class OrderRequestDTO {
         Integer page;
     }
 
-    @Getter
-    public static class OrderItemAddressUpdateDTO {
-        @NotBlank
-        String receiverName;
-        @NotBlank
-        String receiverPhone;
-        @Size(min = 5, max = 6)
-        String zipcode;
-        @NotBlank
-        String address;
-        String addressDetail;
-        String deliveryMemo;
-    }
-
-    @Getter
-    public static class OrderItemRefundInfoUpdateDTO {
-        @NotBlank
-        String refundOwner;
-        @NotBlank
-        String refundBank;
-        @NotBlank
-        String refundAccount;
-    }
-
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/order/OrderResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/order/OrderResponseDTO.java
@@ -151,4 +151,12 @@ public class OrderResponseDTO {
     }
 
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItemUpdateResultDTO {
+        Long orderItemId;
+        LocalDateTime updatedAt;
+    }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
주문 구매 확정 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 주문 관련 DTO, converter, repository, service, converter, validator, ErrorStatus가 추가되었습니다. 

## ⏳ 작업 내용
- [x] 주문 구매 확정 API 구현
- [x] API Swagger 명세
- [x] Validation

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
커밋 히스토리에 보시면 주문 배송지 정보 수정, 환불 계좌 정보 수정 API 구현 내역이 같이 들어가 있는데 제가 로컬 브랜치랑 내용 동기화시키는 과정에서 생긴 커밋들입니다.. 이 pr에서는 해당 API 코드들은 모두 삭제하고 merge 요청 드립니다..! 정보 수정 api는 다른 브랜치에서 pr 따로 드릴게요
