### PR TITLE
[feature/42] 장바구니 등록 API 구현

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_ORDER_OWNER(HttpStatus.BAD_REQUEST, "ORDER4006", "본인의 주문 내역이 아닙니다. 접근할 수 없습니다."),
     NO_LOGIN_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4007", "비회원 주문 내역을 찾을 수 없습니다"),
     ORDER_ITEM_UPDATE_FAIL(HttpStatus.BAD_REQUEST, "ORDER4008", "주문 상품 정보 변경이 불가합니다."),
+    NULL_AMOUNT_ERROR(HttpStatus.BAD_REQUEST, "ORDER4009", "주문 수량은 null일 수 없습니다."),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),

--- a/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
@@ -1,0 +1,12 @@
+package com.umc.TheGoods.converter.cart;
+
+import com.umc.TheGoods.domain.order.Cart;
+
+public class CartConverter {
+    public static Cart toCart(Integer amount) {
+        return Cart.builder()
+                .amount(amount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/umc/TheGoods/domain/order/Cart.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/Cart.java
@@ -34,4 +34,29 @@ public class Cart extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_option_id")
     private ItemOption itemOption;
+
+    // 연관관계 메소드
+    public void setMember(Member member) {
+        if (this.member != null) {
+            this.member.getCartList().remove(this);
+        }
+        this.member = member;
+        member.getCartList().add(this);
+    }
+
+    public void setItem(Item item) {
+        if (this.item != null) {
+            this.item.getItemCartList().remove(this);
+        }
+        this.item = item;
+        item.getItemCartList().add(this);
+    }
+
+    public void setItemOption(ItemOption itemOption) {
+        if (this.itemOption != null) {
+            this.itemOption.getCartList().remove(this);
+        }
+        this.itemOption = itemOption;
+        itemOption.getCartList().add(this);
+    }
 }

--- a/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
@@ -1,0 +1,7 @@
+package com.umc.TheGoods.repository.cart;
+
+import com.umc.TheGoods.domain.order.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+}

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
@@ -1,0 +1,9 @@
+package com.umc.TheGoods.service.CartService;
+
+import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
+
+public interface CartCommandService {
+
+    void addCart(CartRequestDTO.cartAddDTO request, Member member);
+}

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
@@ -50,6 +50,8 @@ public class CartCommandServiceImpl implements CartCommandService {
                     throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
                 }
 
+                // cart 테이블에 해당 장바구니 내역 이미 존재하면, 해당 내역의 담은 수량만 업데이트하는 부분 추가 필요
+
                 // cart 엔티티 생성 및 연관관계 매핑
                 Cart cart = CartConverter.toCart(cartOptionAddDTO.getAmount());
                 cart.setMember(member);
@@ -76,6 +78,9 @@ public class CartCommandServiceImpl implements CartCommandService {
             if (request.getAmount() > item.getStock()) {
                 throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
             }
+
+            // cart 테이블에 해당 장바구니 내역 이미 존재하면, 해당 내역의 담은 수량만 업데이트하는 부분 추가 필요
+
 
             // cart 엔티티 생성 및 연관관계 매핑
             Cart cart = CartConverter.toCart(request.getAmount());

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
@@ -1,0 +1,89 @@
+package com.umc.TheGoods.service.CartService;
+
+import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
+import com.umc.TheGoods.apiPayload.exception.handler.ItemHandler;
+import com.umc.TheGoods.apiPayload.exception.handler.OrderHandler;
+import com.umc.TheGoods.converter.cart.CartConverter;
+import com.umc.TheGoods.domain.item.Item;
+import com.umc.TheGoods.domain.item.ItemOption;
+import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.domain.order.Cart;
+import com.umc.TheGoods.repository.cart.CartRepository;
+import com.umc.TheGoods.service.ItemService.ItemQueryService;
+import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartCommandServiceImpl implements CartCommandService {
+
+    private final ItemQueryService itemQueryService;
+    private final CartRepository cartRepository;
+
+    @Override
+    public void addCart(CartRequestDTO.cartAddDTO request, Member member) {
+        // item, itemOption 존재 여부 검증은 annotation으로 진행
+        Item item = itemQueryService.findItemById(request.getItemId()).get();
+
+        if (!item.getItemOptionList().isEmpty()) { // 옵션이 있는 상품의 경우
+            // request에 optionAddDTO 리스트가 값을 갖고 있는지 검증
+            if (request.getCartOptionAddDTOList().isEmpty()) {
+                throw new OrderHandler(ErrorStatus.NULL_ITEMOPTION_ERROR);
+            }
+
+            // cartList 생성
+            List<Cart> cartList = request.getCartOptionAddDTOList().stream().map(cartOptionAddDTO -> {
+                ItemOption itemOption = itemQueryService.findItemOptionById(cartOptionAddDTO.getItemOptionId()).get();
+                // itemOption이 해당 item의 것이 맞는지 검증
+                if (!itemOption.getItem().equals(item)) {
+                    throw new ItemHandler(ErrorStatus.ITEMOPTION_NOT_MATCH);
+                }
+
+                // 재고 수량과 비교
+                if (cartOptionAddDTO.getAmount() > itemOption.getStock()) {
+                    throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+                }
+
+                // cart 엔티티 생성 및 연관관계 매핑
+                Cart cart = CartConverter.toCart(cartOptionAddDTO.getAmount());
+                cart.setMember(member);
+                cart.setItem(item);
+                cart.setItemOption(itemOption);
+                return cart;
+            }).collect(Collectors.toList());
+
+            // 엔티티 저장
+            cartRepository.saveAll(cartList);
+
+        } else { // 옵션이 없는 상품의 경우
+            // request에 optionAddDTO 리스트가 비어있는지 검증
+            if (!request.getCartOptionAddDTOList().isEmpty()) {
+                throw new ItemHandler(ErrorStatus.ITEMOPTION_NOT_MATCH);
+            }
+
+            // request에 amount 값이 있는지 검증
+            if (request.getAmount() == null) {
+                throw new OrderHandler(ErrorStatus.NULL_AMOUNT_ERROR);
+            }
+
+            // 재고 수량과 비교
+            if (request.getAmount() > item.getStock()) {
+                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+            }
+
+            // cart 엔티티 생성 및 연관관계 매핑
+            Cart cart = CartConverter.toCart(request.getAmount());
+            cart.setMember(member);
+            cart.setItem(item);
+
+            // 엔티티 저장
+            cartRepository.save(cart);
+        }
+    }
+}

--- a/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryService.java
+++ b/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryService.java
@@ -11,4 +11,8 @@ public interface ItemQueryService {
 
     Optional<ItemOption> findItemOptionById(Long id);
 
+    boolean isExistItem(Long id);
+
+    boolean isExistItemOption(Long id);
+
 }

--- a/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryServiceImpl.java
@@ -30,4 +30,14 @@ public class ItemQueryServiceImpl implements ItemQueryService {
         return itemOptionRepository.findById(id);
     }
 
+    @Override
+    public boolean isExistItem(Long id) {
+        return itemRepository.existsById(id);
+    }
+
+    @Override
+    public boolean isExistItemOption(Long id) {
+        return itemOptionRepository.existsById(id);
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/validation/annotation/ExistItem.java
+++ b/src/main/java/com/umc/TheGoods/validation/annotation/ExistItem.java
@@ -1,0 +1,19 @@
+package com.umc.TheGoods.validation.annotation;
+
+import com.umc.TheGoods.validation.validator.ItemExistValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ItemExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistItem {
+    String message() default "해당 상품을 찾을 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/umc/TheGoods/validation/annotation/ExistItemOption.java
+++ b/src/main/java/com/umc/TheGoods/validation/annotation/ExistItemOption.java
@@ -1,0 +1,19 @@
+package com.umc.TheGoods.validation.annotation;
+
+import com.umc.TheGoods.validation.validator.ItemOptionExistValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ItemOptionExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistItemOption {
+    String message() default "해당 상품 옵션을 찾을 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/umc/TheGoods/validation/validator/ItemExistValidator.java
+++ b/src/main/java/com/umc/TheGoods/validation/validator/ItemExistValidator.java
@@ -1,0 +1,32 @@
+package com.umc.TheGoods.validation.validator;
+
+import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
+import com.umc.TheGoods.service.ItemService.ItemQueryService;
+import com.umc.TheGoods.validation.annotation.ExistItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@Component
+@RequiredArgsConstructor
+public class ItemExistValidator implements ConstraintValidator<ExistItem, Long> {
+
+    private final ItemQueryService itemQueryService;
+
+    @Override
+    public void initialize(ExistItem constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = itemQueryService.isExistItem(value);
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ITEM_NOT_FOUND.getMessage()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/com/umc/TheGoods/validation/validator/ItemOptionExistValidator.java
+++ b/src/main/java/com/umc/TheGoods/validation/validator/ItemOptionExistValidator.java
@@ -1,0 +1,32 @@
+package com.umc.TheGoods.validation.validator;
+
+import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
+import com.umc.TheGoods.service.ItemService.ItemQueryService;
+import com.umc.TheGoods.validation.annotation.ExistItemOption;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@Component
+@RequiredArgsConstructor
+public class ItemOptionExistValidator implements ConstraintValidator<ExistItemOption, Long> {
+
+    private final ItemQueryService itemQueryService;
+
+    @Override
+    public void initialize(ExistItemOption constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = itemQueryService.isExistItemOption(value);
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ITEMOPTION_NOT_FOUND.getMessage()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/com/umc/TheGoods/validation/validator/OrderAvailableValidator.java
+++ b/src/main/java/com/umc/TheGoods/validation/validator/OrderAvailableValidator.java
@@ -58,7 +58,7 @@ public class OrderAvailableValidator implements ConstraintValidator<OrderAvailab
 
                 } else { // request에 itemOptionId 값이 없는 경우
                     //item이 단일 상품인지 검증
-                    if (item.get().getPrice() == null) { // item이 단일 상품이 아닌 경우
+                    if (!item.get().getItemOptionList().isEmpty()) { // item이 단일 상품이 아닌 경우
                         context.disableDefaultConstraintViolation();
                         context.buildConstraintViolationWithTemplate(ErrorStatus.NULL_ITEMOPTION_ERROR.getMessage()).addConstraintViolation();
                         return false;

--- a/src/main/java/com/umc/TheGoods/web/controller/CartController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/CartController.java
@@ -8,6 +8,8 @@ import com.umc.TheGoods.service.CartService.CartCommandService;
 import com.umc.TheGoods.service.MemberService.MemberQueryService;
 import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
 import com.umc.TheGoods.web.dto.member.MemberDetail;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +33,13 @@ public class CartController {
     private final CartCommandService cartCommandService;
 
     @PostMapping
+    @Operation(summary = "장바구니 담기 API", description = "해당 상품/옵션을 장바구니에 추가하는 API 입니다.\n\n" +
+            "amount는 해당 상품이 단일 상품인 경우에만 값 입력이 필요합니다.\n\n" +
+            "cartOptionAddDTOList 내부 JSON의 amount는 해당 상품이 옵션이 있는 경우 반드시 값 입력이 필요합니다.\n\n" +
+            "상품이 단일 상품인 경우, cartOptionAddDTOList는 빈 array를 넘겨주세요.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
     public ApiResponse<String> add(@RequestBody @Valid CartRequestDTO.cartAddDTO request,
                                    Authentication authentication) {
         // 비회원인 경우 처리 불가

--- a/src/main/java/com/umc/TheGoods/web/controller/CartController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/CartController.java
@@ -1,0 +1,51 @@
+package com.umc.TheGoods.web.controller;
+
+import com.umc.TheGoods.apiPayload.ApiResponse;
+import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
+import com.umc.TheGoods.apiPayload.exception.handler.MemberHandler;
+import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.service.CartService.CartCommandService;
+import com.umc.TheGoods.service.MemberService.MemberQueryService;
+import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
+import com.umc.TheGoods.web.dto.member.MemberDetail;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Slf4j
+@Tag(name = "Cart", description = "장바구니 관련 API")
+//@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cart")
+public class CartController {
+
+    private final MemberQueryService memberQueryService;
+    private final CartCommandService cartCommandService;
+
+    @PostMapping
+    public ApiResponse<String> add(@RequestBody @Valid CartRequestDTO.cartAddDTO request,
+                                   Authentication authentication) {
+        // 비회원인 경우 처리 불가
+        if (authentication == null) {
+            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        // request에서 member id 추출해 Member 엔티티 찾기
+        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        cartCommandService.addCart(request, member);
+
+        return ApiResponse.onSuccess("장바구니 담기 성공");
+    }
+
+
+}

--- a/src/main/java/com/umc/TheGoods/web/dto/cart/CartRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/cart/CartRequestDTO.java
@@ -1,0 +1,42 @@
+package com.umc.TheGoods.web.dto.cart;
+
+import com.umc.TheGoods.validation.annotation.ExistItem;
+import com.umc.TheGoods.validation.annotation.ExistItemOption;
+import lombok.Getter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public class CartRequestDTO {
+
+    @Getter
+    public static class cartAddDTO {
+        @NotNull
+        @ExistItem
+        Long itemId;
+
+        Integer amount;
+
+        @NotNull
+        @Valid
+        List<cartOptionAddDTO> cartOptionAddDTOList;
+
+    }
+
+    @Getter
+    public static class cartOptionAddDTO {
+        @NotNull
+        @ExistItemOption
+        Long itemOptionId;
+
+        @Min(1)
+        @Max(100000)
+        @NotNull
+        Integer amount;
+
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
장바구니 등록 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- cart 관련 DTO, converter, repository, service, converter, validator, ErrorStatus가 추가되었습니다.

## ⏳ 작업 내용
- [x] 장바구니 등록 API 구현
- [x] API Swagger 명세
- [x] validation

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
현재 장바구니 추가 메소드에는 cart 테이블에 해당 상품/옵션에 대한 장바구니 내역 이미 존재하면, 해당 내역의 담은 수량만 업데이트하는 부분 추가 구현이 필요합니다. 장바구니 옵션 수정 api 개발 후 해당 부분도 추가해서 pr 드리겠습니다!
