### PR TITLE
:sparkles: Feat: 소셜 로그인 구현(카카오, 네이버)(#36)

### DIFF
--- a/src/main/java/com/umc/TheGoods/config/MailConfig.java
+++ b/src/main/java/com/umc/TheGoods/config/MailConfig.java
@@ -5,6 +5,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
+import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 @Component
@@ -15,11 +16,11 @@ public class MailConfig {
     public boolean sendMail(String ToEmail, String code) {
         try {
             MimeMessage message = javaMailSender.createMimeMessage();
+            message.setFrom(new InternetAddress("khjoon8010@gmail.com", "TheGoods", "UTF-8"));
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             helper.setSubject("TheGoods 인증번호 "); // 제목
             helper.setTo(ToEmail); // 받는사람
-            helper.setFrom("thegoodssys@gmail.com");
 
             String verificationCode = code;
             String emailBody = String.format("TheGoods 인증번호는 %s입니다.", verificationCode);

--- a/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
@@ -133,8 +133,25 @@ public class MemberConverter {
     }
 
     public static MemberResponseDTO.EmailAuthConfirmResultDTO toEmailAuthConfirmResultDTO(Boolean checkEmail) {
+
+
         return MemberResponseDTO.EmailAuthConfirmResultDTO.builder()
                 .checkEmail(checkEmail)
+                .build();
+    }
+
+    public static MemberResponseDTO.SocialLoginResultDTO toSocialLoginResultDTO(String result) {
+
+        return MemberResponseDTO.SocialLoginResultDTO.builder()
+                .result(result)
+                .build();
+    }
+
+    public static MemberResponseDTO.SocialJoinResultDTO toSocialJoinResultDTO(String phone, String email) {
+
+        return MemberResponseDTO.SocialJoinResultDTO.builder()
+                .phone(phone)
+                .email(email)
                 .build();
     }
 }

--- a/src/main/java/com/umc/TheGoods/repository/member/MemberRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/member/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByPhone(String phone);
+
 }

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
@@ -29,5 +29,9 @@ public interface MemberCommandService {
 
     Boolean confirmEmailAuth(MemberRequestDTO.EmailAuthConfirmDTO request);
 
+    String kakaoAuth(String code);
+
+    String naverAuth(String code, String state);
+
 
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/member/KakaoProfile.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/KakaoProfile.java
@@ -1,0 +1,25 @@
+package com.umc.TheGoods.web.dto.member;
+
+import lombok.Data;
+
+@Data
+public class KakaoProfile {
+
+    public Long id;
+    public String connected_at;
+    public KakaoAccount kakao_account;
+
+    @Data
+    public class KakaoAccount {
+
+        public Boolean has_email;
+        public Boolean email_needs_agreement;
+        public Boolean is_email_valid;
+        public Boolean is_email_verified;
+        public String email;
+        public Boolean has_phone_number;
+        public Boolean phone_number_needs_agreement;
+        public String phone_number;
+
+    }
+}

--- a/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
@@ -90,4 +90,22 @@ public class MemberResponseDTO {
         Boolean checkEmail;
     }
 
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SocialLoginResultDTO {
+        String result;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SocialJoinResultDTO {
+        String phone;
+        String email;
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/member/NaverProfile.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/NaverProfile.java
@@ -1,0 +1,22 @@
+package com.umc.TheGoods.web.dto.member;
+
+import lombok.Data;
+
+@Data
+public class NaverProfile {
+
+    public String resultcode;
+    public String message;
+    public Response response;
+
+    @Data
+    public class Response {
+
+        public String id;
+        public String email;
+        public String mobile;
+        public String mobile_e164;
+
+    }
+
+}

--- a/src/main/java/com/umc/TheGoods/web/dto/member/OAuthToken.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/OAuthToken.java
@@ -1,0 +1,14 @@
+package com.umc.TheGoods.web.dto.member;
+
+import lombok.Data;
+
+@Data
+public class OAuthToken {
+
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}


### PR DESCRIPTION
# 🚀 개요
소셜 로그인 구현

## 🔍 변경사항
- MemberController, MemberService,DTO추가
- EmailConfig 수정
## ⏳ 작업 내용
- [x] 네이버 로그인 api 구현
- [x] 카카오 로그인 api 구현


### 📝 논의사항


