### PR TITLE
[feature/35] 주문 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/OrderItem.java
@@ -5,6 +5,7 @@ import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.Review;
 import com.umc.TheGoods.domain.types.DeliveryType;
+import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -113,6 +114,27 @@ public class OrderItem extends BaseDateTimeEntity {
     // 주문 상태 업데이트 메소드
     public OrderItem updateStatus(OrderStatus orderStatus) {
         this.status = orderStatus;
+        return this;
+    }
+
+    // 배송지 정보 업데이트 메소드
+    public OrderItem updateAddressInfo(OrderRequestDTO.OrderItemAddressUpdateDTO request) {
+        this.receiverName = request.getReceiverName();
+        this.receiverPhone = request.getReceiverPhone();
+        this.zipcode = request.getZipcode();
+        this.address = request.getAddress();
+        this.addressDetail = request.getAddressDetail();
+        this.deliveryMemo = request.getDeliveryMemo();
+
+        return this;
+    }
+
+    // 환불 계좌 정보 업데이트 메소드
+    public OrderItem updateRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request) {
+        this.refundOwner = request.getRefundOwner();
+        this.refundBank = request.getRefundBank();
+        this.refundAccount = request.getRefundAccount();
+
         return this;
     }
 }

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandService.java
@@ -8,6 +8,10 @@ import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 public interface OrderCommandService {
 
     Orders create(OrderRequestDTO.OrderAddDTO request, Member member);
-    
+
     OrderItem updateStatusToConfirm(Long orderItemId, Member member);
+
+    OrderItem updateOrderItemAddress(OrderRequestDTO.OrderItemAddressUpdateDTO request, Long orderItemId, Member member);
+
+    OrderItem updateOrderItemRefundInfo(OrderRequestDTO.OrderItemRefundInfoUpdateDTO request, Long orderItemId, Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/OrderService/OrderCommandServiceImpl.java
@@ -125,7 +125,15 @@ public class OrderCommandServiceImpl implements OrderCommandService {
             throw new OrderHandler(ErrorStatus.NOT_ORDER_OWNER);
         }
 
-        // orderItem의 status가 환불 계좌 변경 가능한 단계인지 검증 필요
+        // orderItem의 status가 환불 계좌 변경 가능한 단계인지 검증
+        if (!(orderItem.getStatus() == OrderStatus.PAY_PREV
+                || orderItem.getStatus() == OrderStatus.PAY_COMP
+                || orderItem.getStatus() == OrderStatus.DEL_PREP
+                || orderItem.getStatus() == OrderStatus.DEL_START
+                || orderItem.getStatus() == OrderStatus.DEL_COMP
+        )) {
+            throw new OrderHandler(ErrorStatus.ORDER_ITEM_UPDATE_FAIL);
+        }
 
         return orderItem.updateRefundInfo(request);
     }

--- a/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/OrderController.java
@@ -162,4 +162,60 @@ public class OrderController {
 
         return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
     }
+
+    @PutMapping("/{orderItemId}/info/address")
+    @Operation(summary = "주문 배송지 정보 수정 API", description = "상품 주문 내역의 배송지 정보를 변경하는 API 입니다.\n\n" +
+            "orderItemId(상품 주문 내역 id)와 배송지 정보를 보내주세요.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
+    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> updateOrderItemAddress(
+            @RequestBody OrderRequestDTO.OrderItemAddressUpdateDTO request,
+            @PathVariable(name = "orderItemId") Long orderItemId,
+            Authentication authentication
+    ) {
+        Member member = null;
+
+        // 비로그인 요청인 경우 비회원 계정 불러오기
+        if (authentication == null) {
+            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
+        } else {
+            // request에서 member id 추출해 Member 엔티티 찾기
+            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
+
+        OrderItem orderItem = orderCommandService.updateOrderItemAddress(request, orderItemId, member);
+
+        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
+    }
+
+    @PutMapping("/{orderItemId}/info/refund")
+    @Operation(summary = "주문 환불 계좌 정보 수정 API", description = "상품 주문 내역의 환불 계좌 정보를 변경하는 API 입니다.\n\n" +
+            "orderItemId(상품 주문 내역 id)와 환불 계좌 정보를 보내주세요.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "orderItemId", description = "주문 상품 내역 id, path variable 입니다.")
+    public ApiResponse<OrderResponseDTO.OrderItemUpdateResultDTO> updateOrderItemRefundInfo(
+            @RequestBody OrderRequestDTO.OrderItemRefundInfoUpdateDTO request,
+            @PathVariable(name = "orderItemId") Long orderItemId,
+            Authentication authentication
+    ) {
+        Member member = null;
+
+        // 비로그인 요청인 경우 비회원 계정 불러오기
+        if (authentication == null) {
+            member = memberQueryService.findMemberByNickname("no_login_user").orElseThrow(() -> new OrderHandler(ErrorStatus.NO_LOGIN_ORDER_NOT_AVAILABLE));
+        } else {
+            // request에서 member id 추출해 Member 엔티티 찾기
+            MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+            member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
+
+        OrderItem orderItem = orderCommandService.updateOrderItemRefundInfo(request, orderItemId, member);
+
+        return ApiResponse.onSuccess(OrderConverter.toOrderItemUpdateResultDto(orderItem));
+    }
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/order/OrderRequestDTO.java
@@ -85,4 +85,28 @@ public class OrderRequestDTO {
         Integer page;
     }
 
+    @Getter
+    public static class OrderItemAddressUpdateDTO {
+        @NotBlank
+        String receiverName;
+        @NotBlank
+        String receiverPhone;
+        @Size(min = 5, max = 6)
+        String zipcode;
+        @NotBlank
+        String address;
+        String addressDetail;
+        String deliveryMemo;
+    }
+
+    @Getter
+    public static class OrderItemRefundInfoUpdateDTO {
+        @NotBlank
+        String refundOwner;
+        @NotBlank
+        String refundBank;
+        @NotBlank
+        String refundAccount;
+    }
+
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
주문 건의 배송지 정보 수정, 환불 계좌 정보 수정 API 구현


## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 주문 관련 DTO, converter, repository, service, converter가 추가되었습니다.

## ⏳ 작업 내용
- [ ]  주문 배송지 정보 수정 API 구현
- [ ]  주문 환불 계좌 정보 수정 API 구현
- [ ]  API Swagger 명세
- [ ]  Validation

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

