### PR TITLE
[feature] 판매 상품 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/TheGoods/converter/item/ItemConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/item/ItemConverter.java
@@ -7,6 +7,7 @@ import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.types.DeliveryType;
 import com.umc.TheGoods.web.dto.item.ItemRequestDTO;
 import com.umc.TheGoods.web.dto.item.ItemResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -40,6 +41,7 @@ public class ItemConverter {
 
         return ItemResponseDTO.ItemContentDTO.builder()
                 .itemId(item.getId())
+                .name(item.getName())
                 .category(item.getCategory().getName())
                 .deliveryDate(item.getDeliveryDate())
                 .deliveryFee(item.getDeliveryFee())
@@ -57,6 +59,34 @@ public class ItemConverter {
                 .itemTag(item.getItemTagList().stream().map(tag -> tag.getTag().getName()).toList())
                 .itemImgUrlList(itemImgResponseDTOList)
                 .itemOptionList(itemOptionResponseDTOList)
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemPreviewDTO itemPreviewDTO(Item item) {
+        List<ItemResponseDTO.ItemImgResponseDTO> itemImgResponseDTOList = item.getItemImgList().stream()
+                .map(ItemConverter::getItemImgDTO).collect(Collectors.toList());
+
+        return ItemResponseDTO.ItemPreviewDTO.builder()
+                .itemId(item.getId())
+                .name(item.getName())
+                .status(item.getStatus())
+                .itemImgUrlList(itemImgResponseDTOList)
+                .createdAt(item.getCreatedAt())
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemPreviewListDTO itemPreviewListDTO(Page<Item> itemList) {
+
+        List<ItemResponseDTO.ItemPreviewDTO> itemPreviewDTOList = itemList.stream()
+                .map(ItemConverter::itemPreviewDTO).collect(Collectors.toList());
+
+        return ItemResponseDTO.ItemPreviewListDTO.builder()
+                .itemList(itemPreviewDTOList)
+                .isFirst(itemList.isFirst())
+                .isLast(itemList.isLast())
+                .listSize(itemList.getSize())
+                .totalPage(itemList.getTotalPages())
+                .totalElements(itemList.getTotalElements())
                 .build();
     }
 

--- a/src/main/java/com/umc/TheGoods/repository/item/ItemRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/item/ItemRepository.java
@@ -1,7 +1,12 @@
 package com.umc.TheGoods.repository.item;
 
 import com.umc.TheGoods.domain.item.Item;
+import com.umc.TheGoods.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    Page<Item> findAllByMember(Member member, PageRequest pageRequest);
 }

--- a/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryService.java
+++ b/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryService.java
@@ -2,6 +2,8 @@ package com.umc.TheGoods.service.ItemService;
 
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
+import com.umc.TheGoods.domain.member.Member;
+import org.springframework.data.domain.Page;
 
 import java.util.Optional;
 
@@ -15,4 +17,5 @@ public interface ItemQueryService {
 
     boolean isExistItemOption(Long id);
 
+    public Page<Item> getMyItemList(Member member, Integer page);
 }

--- a/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/ItemService/ItemQueryServiceImpl.java
@@ -2,10 +2,14 @@ package com.umc.TheGoods.service.ItemService;
 
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
+import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.repository.item.ItemOptionRepository;
 import com.umc.TheGoods.repository.item.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,4 +44,10 @@ public class ItemQueryServiceImpl implements ItemQueryService {
         return itemOptionRepository.existsById(id);
     }
 
+    @Override
+    @Transactional
+    public Page<Item> getMyItemList(Member member, Integer page) {
+        Page<Item> itemPage = itemRepository.findAllByMember(member, PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt")));
+        return itemPage;
+    }
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/item/ItemResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/item/ItemResponseDTO.java
@@ -37,6 +37,7 @@ public class ItemResponseDTO {
     @AllArgsConstructor
     public static class ItemContentDTO {
         Long itemId;
+        String name;
         ItemStatus status;
         Integer stock;
         Long price;
@@ -54,6 +55,31 @@ public class ItemResponseDTO {
         List<ItemImgResponseDTO> itemImgUrlList;
         List<ItemOptionResponseDTO> itemOptionList;
         List<String> itemTag;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemPreviewListDTO {
+        List<ItemPreviewDTO> itemList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemPreviewDTO {
+        Long itemId;
+        String name;
+        ItemStatus status;
+        List<ItemImgResponseDTO> itemImgUrlList;
+        LocalDateTime createdAt;
     }
 
     @Builder


### PR DESCRIPTION
# 🚀 개요
판매자의 판매 상품을 조회하는 API 입니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 판매자 본인이 판매하고 있는 상품들을 조회하는 API 추가

## ⏳ 작업 내용
- [x] 판매자 상품 목록 조회 API 구현
- [x]  Swagger API 명세서 작성
- [x]  Jwt 적용

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

