### PR TITLE
[feature/67] 장바구니 조회 API 구현 & 장바구니 등록/수정 API 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 장바구니 관련 에러
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CART4001", "해당 장바구니 내역을 찾을 수 없습니다."),
     NOT_CART_OWNER(HttpStatus.BAD_REQUEST, "CART4002", "본인의 장바구니 내역이 아닙니다. 접근할 수 없습니다."),
+    CART_DETAIL_FOUND_ERROR(HttpStatus.NOT_FOUND, "CART4003", "단일 상품의 장바구니 상세 내역을 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),

--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -37,7 +37,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 장바구니 관련 에러
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CART4001", "해당 장바구니 내역을 찾을 수 없습니다."),
     NOT_CART_OWNER(HttpStatus.BAD_REQUEST, "CART4002", "본인의 장바구니 내역이 아닙니다. 접근할 수 없습니다."),
-    CART_DETAIL_FOUND_ERROR(HttpStatus.NOT_FOUND, "CART4003", "단일 상품의 장바구니 상세 내역을 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
+    CART_DETAIL_FOUND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CART4003", "단일 상품의 장바구니 상세 내역을 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
+    CART_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "CART4004", "해당 장바구니 상세 내역을 찾을 수 없습니다"),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),

--- a/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
@@ -1,10 +1,19 @@
 package com.umc.TheGoods.converter.cart;
 
 import com.umc.TheGoods.domain.order.Cart;
+import com.umc.TheGoods.domain.order.CartDetail;
+
+import java.util.ArrayList;
 
 public class CartConverter {
-    public static Cart toCart(Integer amount) {
+    public static Cart toCart() {
         return Cart.builder()
+                .cartDetailList(new ArrayList<>())
+                .build();
+    }
+
+    public static CartDetail toCartDetail(Integer amount) {
+        return CartDetail.builder()
                 .amount(amount)
                 .build();
     }

--- a/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
@@ -2,8 +2,11 @@ package com.umc.TheGoods.converter.cart;
 
 import com.umc.TheGoods.domain.order.Cart;
 import com.umc.TheGoods.domain.order.CartDetail;
+import com.umc.TheGoods.web.dto.cart.CartResponseDTO;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CartConverter {
     public static Cart toCart() {
@@ -18,4 +21,30 @@ public class CartConverter {
                 .build();
     }
 
+    public static CartResponseDTO.cartViewListDTO toCartViewListDTO(List<Cart> cartList) {
+        return CartResponseDTO.cartViewListDTO.builder()
+                .cartViewDTOList(cartList.stream().map(CartConverter::toCartViewDTO).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static CartResponseDTO.cartViewDTO toCartViewDTO(Cart cart) {
+        List<CartResponseDTO.cartDetailViewDTO> cartDetailViewDTOList = cart.getCartDetailList().stream()
+                .map(CartConverter::toCartDetailViewDTO).collect(Collectors.toList());
+
+        return CartResponseDTO.cartViewDTO.builder()
+                .sellerName(cart.getItem().getMember().getNickname())
+                .itemName(cart.getItem().getName())
+                .itemImg("img url") // item 썸네일 가져오는 메소드 필요
+                .deliveryFee(cart.getItem().getDeliveryFee())
+                .cartDetailViewDTOList(cartDetailViewDTOList)
+                .build();
+    }
+
+    public static CartResponseDTO.cartDetailViewDTO toCartDetailViewDTO(CartDetail cartDetail) {
+        return CartResponseDTO.cartDetailViewDTO.builder()
+                .optionName(cartDetail.getItemOption() == null ? null : cartDetail.getItemOption().getName()) // 옵션이 있는 경우에만 옵션 이름 설정
+                .price(cartDetail.getItemOption() == null ? cartDetail.getCart().getItem().getPrice() : cartDetail.getItemOption().getPrice())
+                .amount(cartDetail.getAmount())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/TheGoods/domain/item/ItemOption.java
+++ b/src/main/java/com/umc/TheGoods/domain/item/ItemOption.java
@@ -1,7 +1,7 @@
 package com.umc.TheGoods.domain.item;
 
 import com.umc.TheGoods.domain.common.BaseDateTimeEntity;
-import com.umc.TheGoods.domain.order.Cart;
+import com.umc.TheGoods.domain.order.CartDetail;
 import com.umc.TheGoods.domain.order.OrderDetail;
 import lombok.*;
 
@@ -38,7 +38,7 @@ public class ItemOption extends BaseDateTimeEntity {
     private List<OrderDetail> orderDetailList = new ArrayList<>();
 
     @OneToMany(mappedBy = "itemOption", cascade = CascadeType.ALL)
-    private List<Cart> cartList = new ArrayList<>();
+    private List<CartDetail> cartDetailList = new ArrayList<>();
 
     // 판매수, 재고 관련 메소드
     public ItemOption updateStock(Integer i) {
@@ -46,8 +46,8 @@ public class ItemOption extends BaseDateTimeEntity {
         return this;
     }
 
-    public void setItem(Item item){
-        if(this.item != null)
+    public void setItem(Item item) {
+        if (this.item != null)
             item.getItemOptionList().remove(this);
         this.item = item;
         item.getItemOptionList().add(this);

--- a/src/main/java/com/umc/TheGoods/domain/order/Cart.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/Cart.java
@@ -6,6 +6,8 @@ import com.umc.TheGoods.domain.member.Member;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,6 +28,9 @@ public class Cart extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id", nullable = false)
     private Item item;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
+    private List<CartDetail> cartDetailList = new ArrayList<>();
 
     // 연관관계 메소드
     public void setMember(Member member) {

--- a/src/main/java/com/umc/TheGoods/domain/order/Cart.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/Cart.java
@@ -2,7 +2,6 @@ package com.umc.TheGoods.domain.order;
 
 import com.umc.TheGoods.domain.common.BaseDateTimeEntity;
 import com.umc.TheGoods.domain.item.Item;
-import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.member.Member;
 import lombok.*;
 
@@ -20,9 +19,6 @@ public class Cart extends BaseDateTimeEntity {
     @Column(name = "cart_id")
     private Long id;
 
-    @Column(nullable = false)
-    private Integer amount;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -30,10 +26,6 @@ public class Cart extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id", nullable = false)
     private Item item;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "item_option_id")
-    private ItemOption itemOption;
 
     // 연관관계 메소드
     public void setMember(Member member) {
@@ -52,16 +44,5 @@ public class Cart extends BaseDateTimeEntity {
         item.getItemCartList().add(this);
     }
 
-    public void setItemOption(ItemOption itemOption) {
-        if (this.itemOption != null) {
-            this.itemOption.getCartList().remove(this);
-        }
-        this.itemOption = itemOption;
-        itemOption.getCartList().add(this);
-    }
 
-    public Cart updateAmount(Integer amount) {
-        this.amount = amount;
-        return this;
-    }
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
@@ -37,7 +37,6 @@ public class CartDetail extends BaseDateTimeEntity {
         cart.getCartDetailList().add(this);
     }
 
-
     public void setItemOption(ItemOption itemOption) {
         if (this.itemOption != null) {
             this.itemOption.getCartDetailList().remove(this);

--- a/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
@@ -21,10 +21,21 @@ public class CartDetail extends BaseDateTimeEntity {
     @Column(nullable = false)
     private Integer amount;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_option_id")
     private ItemOption itemOption;
+
+    public void setCart(Cart cart) {
+        if (this.cart != null) {
+            this.cart.getCartDetailList().remove(this);
+        }
+        this.cart = cart;
+        cart.getCartDetailList().add(this);
+    }
 
 
     public void setItemOption(ItemOption itemOption) {

--- a/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
@@ -1,0 +1,42 @@
+package com.umc.TheGoods.domain.order;
+
+import com.umc.TheGoods.domain.common.BaseDateTimeEntity;
+import com.umc.TheGoods.domain.item.ItemOption;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CartDetail extends BaseDateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cart_detail_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_option_id")
+    private ItemOption itemOption;
+
+
+    public void setItemOption(ItemOption itemOption) {
+        if (this.itemOption != null) {
+            this.itemOption.getCartDetailList().remove(this);
+        }
+        this.itemOption = itemOption;
+        itemOption.getCartDetailList().add(this);
+    }
+
+    public CartDetail updateAmount(Integer amount) {
+        this.amount = amount;
+        return this;
+    }
+}

--- a/src/main/java/com/umc/TheGoods/repository/cart/CartDetailRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/cart/CartDetailRepository.java
@@ -1,0 +1,15 @@
+package com.umc.TheGoods.repository.cart;
+
+import com.umc.TheGoods.domain.item.ItemOption;
+import com.umc.TheGoods.domain.order.Cart;
+import com.umc.TheGoods.domain.order.CartDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartDetailRepository extends JpaRepository<CartDetail, Long> {
+    Optional<CartDetail> findByCartAndItemOption(Cart cart, ItemOption itemOption);
+
+    Optional<CartDetail> findByCart(Cart cart);
+
+}

--- a/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
@@ -1,7 +1,6 @@
 package com.umc.TheGoods.repository.cart;
 
 import com.umc.TheGoods.domain.item.Item;
-import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,8 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
-
-    Optional<Cart> findByMemberAndItemAndItemOption(Member member, Item item, ItemOption itemOption);
 
     Optional<Cart> findByMemberAndItem(Member member, Item item);
 

--- a/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
@@ -5,10 +5,13 @@ import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByMemberAndItem(Member member, Item item);
+
+    List<Cart> findAllByMember(Member member);
 
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
@@ -9,4 +9,5 @@ public interface CartCommandService {
     void addCart(CartRequestDTO.cartAddDTO request, Member member);
 
     CartDetail updateCart(CartRequestDTO.cartUpdateDTO request, Member member);
+
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
@@ -1,11 +1,12 @@
 package com.umc.TheGoods.service.CartService;
 
 import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.domain.order.CartDetail;
 import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
 
 public interface CartCommandService {
 
     void addCart(CartRequestDTO.cartAddDTO request, Member member);
 
-    //Cart updateCart(CartRequestDTO.cartUpdateDTO request, Member member);
+    CartDetail updateCart(CartRequestDTO.cartUpdateDTO request, Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandService.java
@@ -1,12 +1,11 @@
 package com.umc.TheGoods.service.CartService;
 
 import com.umc.TheGoods.domain.member.Member;
-import com.umc.TheGoods.domain.order.Cart;
 import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
 
 public interface CartCommandService {
 
     void addCart(CartRequestDTO.cartAddDTO request, Member member);
 
-    Cart updateCart(CartRequestDTO.cartUpdateDTO request, Member member);
+    //Cart updateCart(CartRequestDTO.cartUpdateDTO request, Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
@@ -135,27 +135,27 @@ public class CartCommandServiceImpl implements CartCommandService {
         }
     }
 
-//    @Override
-//    public Cart updateCart(CartRequestDTO.cartUpdateDTO request, Member member) {
-//        // cart 존재 여부 검증은 annotation에서 진행
-//        Cart cart = cartRepository.findById(request.getCartId()).get();
-//
-//        // 해당 cart 내역을 수정할 권한 있는지 검증
-//        if (!cart.getMember().equals(member)) {
-//            throw new OrderHandler(ErrorStatus.NOT_CART_OWNER);
-//        }
-//
-//        // 재고 수량과 비교
-//        if (!cart.getItem().getItemOptionList().isEmpty()) { // 상품 옵션이 있는 경우
-//            if (request.getAmount() > cart.getItemOption().getStock()) {
-//                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
-//            }
-//        } else {
-//            if (request.getAmount() > cart.getItem().getStock()) {
-//                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
-//            }
-//        }
-//
-//        return cart.updateAmount(request.getAmount());
-//    }
+    @Override
+    public CartDetail updateCart(CartRequestDTO.cartUpdateDTO request, Member member) {
+        // cartDetail 존재 여부 검증은 annotation에서 진행
+        CartDetail cartDetail = cartDetailRepository.findById(request.getCartDetailId()).get();
+
+        // 해당 cart 내역을 수정할 권한 있는지 검증
+        if (!cartDetail.getCart().getMember().equals(member)) {
+            throw new OrderHandler(ErrorStatus.NOT_CART_OWNER);
+        }
+
+        // 재고 수량과 비교
+        if (!cartDetail.getCart().getItem().getItemOptionList().isEmpty()) { // 상품 옵션이 있는 경우
+            if (request.getAmount() > cartDetail.getItemOption().getStock()) {
+                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+            }
+        } else {
+            if (request.getAmount() > cartDetail.getCart().getItem().getStock()) {
+                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+            }
+        }
+
+        return cartDetail.updateAmount(request.getAmount());
+    }
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
@@ -65,7 +65,7 @@ public class CartCommandServiceImpl implements CartCommandService {
                         existCartDetail.get().updateAmount(existCartDetail.get().getAmount() + cartOptionAddDTO.getAmount());
                         cartDetailRepository.save(existCartDetail.get());
 
-                    } else { // cart 내역은 존재하지만 cartDetail 내역은 존재하지 않는 경우
+                    } else { // cart 내역은 존재하지만 cartDetail 내역은 존재하지 않는 경
                         // 신규 장바구니 상세 내역 생성
                         CartDetail cartDetail = CartConverter.toCartDetail(cartOptionAddDTO.getAmount());
                         cartDetail.setCart(cart.get());
@@ -158,4 +158,5 @@ public class CartCommandServiceImpl implements CartCommandService {
 
         return cartDetail.updateAmount(request.getAmount());
     }
+
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
@@ -8,6 +8,8 @@ import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.Cart;
+import com.umc.TheGoods.domain.order.CartDetail;
+import com.umc.TheGoods.repository.cart.CartDetailRepository;
 import com.umc.TheGoods.repository.cart.CartRepository;
 import com.umc.TheGoods.service.ItemService.ItemQueryService;
 import com.umc.TheGoods.web.dto.cart.CartRequestDTO;
@@ -15,9 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,7 @@ public class CartCommandServiceImpl implements CartCommandService {
 
     private final ItemQueryService itemQueryService;
     private final CartRepository cartRepository;
+    private final CartDetailRepository cartDetailRepository;
 
     @Override
     public void addCart(CartRequestDTO.cartAddDTO request, Member member) {
@@ -38,8 +39,8 @@ public class CartCommandServiceImpl implements CartCommandService {
                 throw new OrderHandler(ErrorStatus.NULL_ITEMOPTION_ERROR);
             }
 
-            // cartList 생성
-            List<Cart> cartList = request.getCartOptionAddDTOList().stream().map(cartOptionAddDTO -> {
+            // cartOptionAddDTOList를 돌며 cart, cartDetail 엔티티 생성 및 업데이트
+            request.getCartOptionAddDTOList().forEach(cartOptionAddDTO -> {
                 ItemOption itemOption = itemQueryService.findItemOptionById(cartOptionAddDTO.getItemOptionId()).get();
                 // itemOption이 해당 item의 것이 맞는지 검증
                 if (!itemOption.getItem().equals(item)) {
@@ -52,28 +53,41 @@ public class CartCommandServiceImpl implements CartCommandService {
                 }
 
                 // cart 테이블에 해당 장바구니 내역 이미 존재하면, 해당 내역의 담은 수량만 업데이트
-                Optional<Cart> existCart = cartRepository.findByMemberAndItemAndItemOption(member, item, itemOption);
-                if (!existCart.isEmpty()) { // 장바구니 내역 이미 존재하는 경우
-                    // 재고 수량과 비교
-                    if (cartOptionAddDTO.getAmount() + existCart.get().getAmount() > itemOption.getStock()) {
-                        throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+                Optional<Cart> cart = cartRepository.findByMemberAndItem(member, item);
+                if (cart.isPresent()) {  // cart 테이블에 해당 장바구니 내역 존재하는 경우
+                    Optional<CartDetail> existCartDetail = cartDetailRepository.findByCartAndItemOption(cart.get(), itemOption);
+                    if (!existCartDetail.isEmpty()) { // cartDetail 테이블에 해당 옵션 내역 이미 존재하는 경우
+                        // 재고 수량과 비교
+                        if (cartOptionAddDTO.getAmount() + existCartDetail.get().getAmount() > itemOption.getStock()) {
+                            throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+                        }
+                        // 장바구니 상세 내역의 수량 업데이트
+                        existCartDetail.get().updateAmount(existCartDetail.get().getAmount() + cartOptionAddDTO.getAmount());
+                        cartDetailRepository.save(existCartDetail.get());
+
+                    } else { // cart 내역은 존재하지만 cartDetail 내역은 존재하지 않는 경우
+                        // 신규 장바구니 상세 내역 생성
+                        CartDetail cartDetail = CartConverter.toCartDetail(cartOptionAddDTO.getAmount());
+                        cartDetail.setCart(cart.get());
+                        cartDetail.setItemOption(itemOption);
+                        cartDetailRepository.save(cartDetail);
                     }
 
-                    // 장바구니 내역의 수량 업데이트
-                    existCart.get().updateAmount(existCart.get().getAmount() + cartOptionAddDTO.getAmount());
-                    return existCart.get();
-                } else { // 신규 장바구니 내역 생성
-                    // cart 엔티티 생성 및 연관관계 매핑
-                    Cart cart = CartConverter.toCart(cartOptionAddDTO.getAmount());
-                    cart.setMember(member);
-                    cart.setItem(item);
-                    cart.setItemOption(itemOption);
-                    return cart;
-                }
-            }).collect(Collectors.toList());
+                } else { // cart 테이블에 해당 장바구니 내역이 없는 경우
+                    // 신규 장바구니 내역 생성
+                    Cart newCart = CartConverter.toCart();
+                    newCart.setMember(member);
+                    newCart.setItem(item);
 
-            // 엔티티 저장
-            cartRepository.saveAll(cartList);
+                    // 신규 장바구니 상세 내역 생성
+                    CartDetail newCartDetail = CartConverter.toCartDetail(cartOptionAddDTO.getAmount());
+                    newCartDetail.setCart(newCart);
+                    newCartDetail.setItemOption(itemOption);
+
+                    cartRepository.save(newCart);
+                    cartDetailRepository.save(newCartDetail);
+                }
+            });
 
         } else { // 옵션이 없는 상품의 경우
             // request에 optionAddDTO 리스트가 비어있는지 검증
@@ -91,51 +105,57 @@ public class CartCommandServiceImpl implements CartCommandService {
                 throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
             }
 
-            Optional<Cart> existCart = cartRepository.findByMemberAndItem(member, item);
-            if (!existCart.isEmpty()) { // 장바구니 내역 이미 존재하는 경우
+            Optional<Cart> cart = cartRepository.findByMemberAndItem(member, item);
+            if (cart.isPresent()) { // 장바구니 내역 이미 존재하는 경우
+                CartDetail cartDetail = cartDetailRepository.findByCart(cart.get()).orElseThrow(() -> new OrderHandler(ErrorStatus.CART_DETAIL_FOUND_ERROR));
+
                 // 재고 수량과 비교
-                if (request.getAmount() + existCart.get().getAmount() > item.getStock()) {
+                if (request.getAmount() + cartDetail.getAmount() > item.getStock()) {
                     throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
                 }
 
                 // 장바구니 내역의 수량 업데이트
-                existCart.get().updateAmount(request.getAmount());
-            } else { // 장바구니 내역 신규 생성
+                cartDetail.updateAmount(request.getAmount());
+                cartDetailRepository.save(cartDetail);
 
-                // cart 엔티티 생성 및 연관관계 매핑
-                Cart cart = CartConverter.toCart(request.getAmount());
-                cart.setMember(member);
-                cart.setItem(item);
+            } else { // 장바구니 및 상세 내역 신규 생성
 
-                // 엔티티 저장
-                cartRepository.save(cart);
+                // 신규 장바구니 내역 생성
+                Cart newCart = CartConverter.toCart();
+                newCart.setMember(member);
+                newCart.setItem(item);
+
+                // 신규 장바구니 상세 내역 생성
+                CartDetail newCartDetail = CartConverter.toCartDetail(request.getAmount());
+                newCartDetail.setCart(newCart);
+
+                cartRepository.save(newCart);
+                cartDetailRepository.save(newCartDetail);
             }
-
-
         }
     }
 
-    @Override
-    public Cart updateCart(CartRequestDTO.cartUpdateDTO request, Member member) {
-        // cart 존재 여부 검증은 annotation에서 진행
-        Cart cart = cartRepository.findById(request.getCartId()).get();
-
-        // 해당 cart 내역을 수정할 권한 있는지 검증
-        if (!cart.getMember().equals(member)) {
-            throw new OrderHandler(ErrorStatus.NOT_CART_OWNER);
-        }
-
-        // 재고 수량과 비교
-        if (!cart.getItem().getItemOptionList().isEmpty()) { // 상품 옵션이 있는 경우
-            if (request.getAmount() > cart.getItemOption().getStock()) {
-                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
-            }
-        } else {
-            if (request.getAmount() > cart.getItem().getStock()) {
-                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
-            }
-        }
-
-        return cart.updateAmount(request.getAmount());
-    }
+//    @Override
+//    public Cart updateCart(CartRequestDTO.cartUpdateDTO request, Member member) {
+//        // cart 존재 여부 검증은 annotation에서 진행
+//        Cart cart = cartRepository.findById(request.getCartId()).get();
+//
+//        // 해당 cart 내역을 수정할 권한 있는지 검증
+//        if (!cart.getMember().equals(member)) {
+//            throw new OrderHandler(ErrorStatus.NOT_CART_OWNER);
+//        }
+//
+//        // 재고 수량과 비교
+//        if (!cart.getItem().getItemOptionList().isEmpty()) { // 상품 옵션이 있는 경우
+//            if (request.getAmount() > cart.getItemOption().getStock()) {
+//                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+//            }
+//        } else {
+//            if (request.getAmount() > cart.getItem().getStock()) {
+//                throw new OrderHandler(ErrorStatus.LACK_OF_STOCK);
+//            }
+//        }
+//
+//        return cart.updateAmount(request.getAmount());
+//    }
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartQueryService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartQueryService.java
@@ -3,4 +3,6 @@ package com.umc.TheGoods.service.CartService;
 public interface CartQueryService {
 
     boolean isExistCart(Long cartId);
+
+    boolean isExistCartDetail(Long cartDetailId);
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartQueryService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartQueryService.java
@@ -1,6 +1,14 @@
 package com.umc.TheGoods.service.CartService;
 
+import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.domain.order.Cart;
+
+import java.util.List;
+
 public interface CartQueryService {
+
+    List<Cart> getCartList(Member member);
+
 
     boolean isExistCart(Long cartId);
 

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.umc.TheGoods.service.CartService;
 
+import com.umc.TheGoods.repository.cart.CartDetailRepository;
 import com.umc.TheGoods.repository.cart.CartRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,10 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class CartQueryServiceImpl implements CartQueryService {
 
     private final CartRepository cartRepository;
+    private final CartDetailRepository cartDetailRepository;
 
 
     @Override
     public boolean isExistCart(Long cartId) {
         return cartRepository.existsById(cartId);
+    }
+
+    @Override
+    public boolean isExistCartDetail(Long cartDetailId) {
+        return cartDetailRepository.existsById(cartDetailId);
     }
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartQueryServiceImpl.java
@@ -1,10 +1,14 @@
 package com.umc.TheGoods.service.CartService;
 
+import com.umc.TheGoods.domain.member.Member;
+import com.umc.TheGoods.domain.order.Cart;
 import com.umc.TheGoods.repository.cart.CartDetailRepository;
 import com.umc.TheGoods.repository.cart.CartRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +17,11 @@ public class CartQueryServiceImpl implements CartQueryService {
 
     private final CartRepository cartRepository;
     private final CartDetailRepository cartDetailRepository;
+
+    @Override
+    public List<Cart> getCartList(Member member) {
+        return cartRepository.findAllByMember(member);
+    }
 
 
     @Override

--- a/src/main/java/com/umc/TheGoods/validation/annotation/ExistCartDetail.java
+++ b/src/main/java/com/umc/TheGoods/validation/annotation/ExistCartDetail.java
@@ -1,0 +1,19 @@
+package com.umc.TheGoods.validation.annotation;
+
+import com.umc.TheGoods.validation.validator.CartDetailExistValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CartDetailExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistCartDetail {
+    String message() default "해당 장바구니 상세 내역을 찾을 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/umc/TheGoods/validation/validator/CartDetailExistValidator.java
+++ b/src/main/java/com/umc/TheGoods/validation/validator/CartDetailExistValidator.java
@@ -1,0 +1,32 @@
+package com.umc.TheGoods.validation.validator;
+
+import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
+import com.umc.TheGoods.service.CartService.CartQueryService;
+import com.umc.TheGoods.validation.annotation.ExistCartDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@Component
+@RequiredArgsConstructor
+public class CartDetailExistValidator implements ConstraintValidator<ExistCartDetail, Long> {
+
+    private final CartQueryService cartQueryService;
+
+    @Override
+    public void initialize(ExistCartDetail constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = cartQueryService.isExistCartDetail(value);
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.CART_DETAIL_NOT_FOUND.getMessage()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/com/umc/TheGoods/web/controller/CartController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/CartController.java
@@ -14,10 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -56,26 +53,26 @@ public class CartController {
         return ApiResponse.onSuccess("장바구니 담기 성공");
     }
 
-//    @PutMapping
-//    @Operation(summary = "장바구니 옵션 수정 API", description = "해당 장바구니 내역의 담은 수량을 수정하는 API 입니다.")
-//    @ApiResponses(value = {
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-//    })
-//    public ApiResponse<String> update(@RequestBody @Valid CartRequestDTO.cartUpdateDTO request,
-//                                      Authentication authentication) {
-//        // 비회원인 경우 처리 불가
-//        if (authentication == null) {
-//            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
-//        }
-//
-//        // request에서 member id 추출해 Member 엔티티 찾기
-//        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
-//        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-//
-//        cartCommandService.updateCart(request, member);
-//
-//        return ApiResponse.onSuccess("장바구니 옵션 수정 성공");
-//    }
+    @PutMapping
+    @Operation(summary = "장바구니 옵션 수정 API", description = "해당 장바구니 내역의 담은 수량을 수정하는 API 입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<String> update(@RequestBody @Valid CartRequestDTO.cartUpdateDTO request,
+                                      Authentication authentication) {
+        // 비회원인 경우 처리 불가
+        if (authentication == null) {
+            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        // request에서 member id 추출해 Member 엔티티 찾기
+        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        cartCommandService.updateCart(request, member);
+
+        return ApiResponse.onSuccess("장바구니 옵션 수정 성공");
+    }
 
 
 }

--- a/src/main/java/com/umc/TheGoods/web/controller/CartController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/CartController.java
@@ -14,7 +14,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
@@ -53,26 +56,26 @@ public class CartController {
         return ApiResponse.onSuccess("장바구니 담기 성공");
     }
 
-    @PutMapping
-    @Operation(summary = "장바구니 옵션 수정 API", description = "해당 장바구니 내역의 담은 수량을 수정하는 API 입니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-    })
-    public ApiResponse<String> update(@RequestBody @Valid CartRequestDTO.cartUpdateDTO request,
-                                      Authentication authentication) {
-        // 비회원인 경우 처리 불가
-        if (authentication == null) {
-            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
-        }
-
-        // request에서 member id 추출해 Member 엔티티 찾기
-        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
-        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        cartCommandService.updateCart(request, member);
-
-        return ApiResponse.onSuccess("장바구니 옵션 수정 성공");
-    }
+//    @PutMapping
+//    @Operation(summary = "장바구니 옵션 수정 API", description = "해당 장바구니 내역의 담은 수량을 수정하는 API 입니다.")
+//    @ApiResponses(value = {
+//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+//    })
+//    public ApiResponse<String> update(@RequestBody @Valid CartRequestDTO.cartUpdateDTO request,
+//                                      Authentication authentication) {
+//        // 비회원인 경우 처리 불가
+//        if (authentication == null) {
+//            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
+//        }
+//
+//        // request에서 member id 추출해 Member 엔티티 찾기
+//        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+//        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+//
+//        cartCommandService.updateCart(request, member);
+//
+//        return ApiResponse.onSuccess("장바구니 옵션 수정 성공");
+//    }
 
 
 }

--- a/src/main/java/com/umc/TheGoods/web/controller/CartController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/CartController.java
@@ -60,6 +60,10 @@ public class CartController {
     }
 
     @GetMapping
+    @Operation(summary = "나의 장바구니 목록 조회 API", description = "나의 장바구니 목록을 조회하는 API 입니다. (구매자 회원용")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
     public ApiResponse<CartResponseDTO.cartViewListDTO> cartView(Authentication authentication) {
         // 비회원인 경우 처리 불가
         if (authentication == null) {

--- a/src/main/java/com/umc/TheGoods/web/dto/cart/CartRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/cart/CartRequestDTO.java
@@ -1,6 +1,6 @@
 package com.umc.TheGoods.web.dto.cart;
 
-import com.umc.TheGoods.validation.annotation.ExistCart;
+import com.umc.TheGoods.validation.annotation.ExistCartDetail;
 import com.umc.TheGoods.validation.annotation.ExistItem;
 import com.umc.TheGoods.validation.annotation.ExistItemOption;
 import lombok.Getter;
@@ -43,8 +43,8 @@ public class CartRequestDTO {
     @Getter
     public static class cartUpdateDTO {
         @NotNull
-        @ExistCart
-        Long cartId;
+        @ExistCartDetail
+        Long cartDetailId;
 
         @Min(1)
         @Max(100000)

--- a/src/main/java/com/umc/TheGoods/web/dto/cart/CartResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/cart/CartResponseDTO.java
@@ -1,0 +1,41 @@
+package com.umc.TheGoods.web.dto.cart;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class CartResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class cartViewListDTO {
+        List<cartViewDTO> cartViewDTOList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class cartViewDTO {
+        String sellerName;
+        String itemName;
+        String itemImg;
+        Integer deliveryFee;
+        List<cartDetailViewDTO> cartDetailViewDTOList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class cartDetailViewDTO {
+        String optionName;
+        Long price;
+        Integer amount;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
 jwt:
   token:
     secret: "secretKey"


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
장바구니 내역 조회 API 구현 및 기존 장바구니 등록 API, 장바구니 옵션 수정 API 수정
장바구니 엔티티를 장바구니 - 장바구니 상세 엔티티로 분리

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 엔티티 변경으로 인해 개발 서버의 application-dev.yml을 ddl-auto: create로 설정했습니다.
- CartDetail(장바구니 상세 내역) 엔티티가 추가되었습니다.
- Cart <-> ItemOption 엔티티 간 연관관계가 CartDetail <-> ItemOption으로 변경되었습니다.
- cart 관련 DTO, converter, repository, service, converter, validator, ErrorStatus가 추가되었습니다.

## ⏳ 작업 내용
- [x] 장바구니 엔티티 수정
- [x] 장바구니 내역 조회 API 구현
- [x] 장바구니 등록 API 수정
- [x] 장바구니 옵션 수정 API 수정
- [x] API Swagger 명세
- [x] Validation

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
엔티티 변경으로 인해 로컬 db ddl-auto: create 한 번 필요합니다..
개발 서버는 지금 merge 되면서 재생성 시켜야해서 create로 바꿔 두었는데, 다음 pr 하실 때 다시 update로 바꿔주신 후 pr merge 해주시면 될 것 같아요!
