### PR TITLE
:sparkles: Feat: 새로운 비밀번호 설정 api 구현(#80)

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -50,6 +50,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4004", "해당 회원을 찾을 수 없습니다."),
     MEMBER_PHONE_AUTH_ERROR(HttpStatus.BAD_REQUEST, "MEMBER4005", "유효하지 않는 번호입니다."),
     MEMBER_EMAIL_AUTH_ERROR(HttpStatus.BAD_REQUEST, "MEMBER4006", "유효하지 않는 이메일입니다."),
+    MEMBER_PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST, "MEMBER4007", "비밀번호가 일치하지 않습니다."),
 
 
     //Category

--- a/src/main/java/com/umc/TheGoods/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/umc/TheGoods/aws/s3/AmazonS3Manager.java
@@ -36,6 +36,11 @@ public class AmazonS3Manager {
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
 
+    public String getUrl(String keyName) {
+        keyName = amazonConfig.getMemberPath() + '/' + keyName;
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
     public String generateMemberKeyName(Uuid uuid) {
         return amazonConfig.getMemberPath() + '/' + uuid.getUuid();
     }

--- a/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
@@ -3,6 +3,7 @@ package com.umc.TheGoods.converter.member;
 import com.umc.TheGoods.domain.enums.MemberRole;
 import com.umc.TheGoods.domain.images.ProfileImg;
 import com.umc.TheGoods.domain.item.Category;
+import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.mapping.member.MemberCategory;
 import com.umc.TheGoods.domain.mapping.member.MemberTerm;
 import com.umc.TheGoods.domain.member.Auth;
@@ -50,6 +51,36 @@ public class MemberConverter {
                 .itemList(new ArrayList<>())
                 .build();
 
+    }
+
+    public static Member toUpdatePassword(Member member, String password) {
+        List<MemberTerm> memberTermList = member.getMemberTermList();
+        List<MemberCategory> memberCategoryList = member.getMemberCategoryList();
+        List<Item> memberItemList = member.getItemList();
+        if (memberItemList == null) {
+            memberItemList = new ArrayList<>();
+        }
+
+        if (memberTermList == null) {
+            memberTermList = new ArrayList<>();
+        }
+
+        if (memberCategoryList == null) {
+            memberCategoryList = new ArrayList<>();
+        }
+        return Member.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .password(password)
+                .email(member.getEmail())
+                .birthday(member.getBirthday())
+                .gender(member.getGender())
+                .phone(member.getPhone())
+                .memberRole(MemberRole.BUYER)
+                .memberCategoryList(memberCategoryList)
+                .memberTermList(memberTermList)
+                .itemList(memberItemList)
+                .build();
     }
 
     public static List<MemberCategory> toMemberCategoryList(List<Category> categoryList) {
@@ -174,4 +205,44 @@ public class MemberConverter {
                 .url(url)
                 .build();
     }
+
+    public static MemberResponseDTO.PasswordUpdateResultDTO toPasswordUpdateResultDTO(boolean updatePassword) {
+        return MemberResponseDTO.PasswordUpdateResultDTO.builder()
+                .updatePassword(updatePassword)
+                .build();
+    }
+
+    public static Member toUpdateProfile(Member member, ProfileImg profileImg, String nickname, String introduce) {
+        List<MemberTerm> memberTermList = member.getMemberTermList();
+        List<MemberCategory> memberCategoryList = member.getMemberCategoryList();
+        List<Item> memberItemList = member.getItemList();
+        if (memberItemList == null) {
+            memberItemList = new ArrayList<>();
+        }
+
+        if (memberTermList == null) {
+            memberTermList = new ArrayList<>();
+        }
+
+        if (memberCategoryList == null) {
+            memberCategoryList = new ArrayList<>();
+        }
+        return Member.builder()
+                .id(member.getId())
+                .nickname(nickname)
+                .password(member.getPassword())
+                .email(member.getEmail())
+                .birthday(member.getBirthday())
+                .gender(member.getGender())
+                .phone(member.getPhone())
+                .memberRole(MemberRole.BUYER)
+                .memberCategoryList(memberCategoryList)
+                .memberTermList(memberTermList)
+                .itemList(memberItemList)
+                .introduce(introduce)
+                .profileImg(profileImg)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/umc/TheGoods/domain/member/Member.java
+++ b/src/main/java/com/umc/TheGoods/domain/member/Member.java
@@ -204,16 +204,5 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Payment> paymentList = new ArrayList<>();
 
-    public void setProfileImg(ProfileImg profileImg) {
 
-        this.profileImg = profileImg;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public void setIntroduce(String introduce) {
-        this.introduce = introduce;
-    }
 }

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
@@ -30,6 +30,8 @@ public interface MemberCommandService {
 
     Boolean confirmEmailAuth(MemberRequestDTO.EmailAuthConfirmDTO request);
 
+    Boolean updatePassword(MemberRequestDTO.PasswordUpdateDTO request, Member member);
+
     String kakaoAuth(String code);
 
     String naverAuth(String code, String state);

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandServiceImpl.java
@@ -63,6 +63,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private String key; // 토큰 만들어내는 key값
     private int expiredMs = 1000 * 60 * 60 * 24 * 5;// 토큰 만료 시간 1일
 
+
     /**
      * 회원가입 api
      *
@@ -316,6 +317,18 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
+    public Boolean updatePassword(MemberRequestDTO.PasswordUpdateDTO request, Member member) {
+        boolean updatePassword = true;
+
+        Member update = MemberConverter.toUpdatePassword(member, encoder.encode(request.getPassword()));
+
+        memberRepository.save(update);
+
+        return updatePassword;
+    }
+
+    @Override
+    @Transactional
     public String kakaoAuth(String code) {
 
         String jwt;
@@ -505,12 +518,11 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         String profileUrl = s3Manager.uploadFile(s3Manager.generateMemberKeyName(saveUuid), profile);
 
         ProfileImg profileImg = MemberConverter.toProfileImg(profileUrl, member);
-
-        member.setProfileImg(profileImg);
-        member.setNickname(nickname);
-        member.setIntroduce(introduce);
-        memberRepository.save(member);
         profileImgRepository.save(profileImg);
+
+        Member update = MemberConverter.toUpdateProfile(member, profileImg, nickname, introduce);
+        memberRepository.save(update);
+
 
         return member;
     }

--- a/src/main/java/com/umc/TheGoods/web/controller/MemberController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/MemberController.java
@@ -128,6 +128,22 @@ public class MemberController {
         return ApiResponse.onSuccess(MemberConverter.toEmailAuthConfirmResultDTO(checkEmail));
     }
 
+    @PostMapping("password/update")
+    @Operation(summary = "새로운 비밀번호 설정 api", description = "request: 비밀번호, 비밀번호 확인 response: 변경완료 true")
+    public ApiResponse<MemberResponseDTO.PasswordUpdateResultDTO> updatePassword(@RequestBody MemberRequestDTO.PasswordUpdateDTO request, Authentication authentication) {
+
+        if (request.getPassword() != request.getCheckPassword()) {
+            new MemberHandler(ErrorStatus.MEMBER_PASSWORD_NOT_EQUAL);
+        }
+
+        MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();
+        Member member = memberQueryService.findMemberById(memberDetail.getMemberId()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Boolean updatePassword = memberCommandService.updatePassword(request, member);
+
+        return ApiResponse.onSuccess(MemberConverter.toPasswordUpdateResultDTO(updatePassword));
+    }
+
 
     @GetMapping("/kakao/callback")
     @Operation(summary = "카카오 소셜 로그인 api", description = "callback 용도 api여서 swagger에서 test 안됩니다")
@@ -182,6 +198,7 @@ public class MemberController {
     }
 
     @GetMapping(value = "/profile")
+    @Operation(summary = "프로필 조회 api", description = "프로필이미지, 닉네임을 조회할 수 있습니다.")
     public ApiResponse<MemberResponseDTO.ProfileResultDTO> getProfile(Authentication authentication) {
 
         MemberDetail memberDetail = (MemberDetail) authentication.getPrincipal();

--- a/src/main/java/com/umc/TheGoods/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/MemberRequestDTO.java
@@ -90,4 +90,12 @@ public class MemberRequestDTO {
     }
 
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PasswordUpdateDTO {
+        private String password;
+        private String checkPassword;
+    }
+
 }

--- a/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
@@ -90,6 +90,14 @@ public class MemberResponseDTO {
         Boolean checkEmail;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PasswordUpdateResultDTO {
+        boolean updatePassword;
+    }
+
 
     @Builder
     @Getter
@@ -124,5 +132,6 @@ public class MemberResponseDTO {
         String nickname;
         String url;
     }
+
 
 }


### PR DESCRIPTION
# 🚀 개요
비밀번호 변경 api 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- setter 사용해서 데이터 변경했던 로직들 변경

## ⏳ 작업 내용
- [x] 비밀번호와 비밀번호 확인의 내용을 비교하고 동일하면 해당 사용자의 비밀번호 변경 


