### PR TITLE
:recycle: Refactor: 장바구니 내역 조회, 주문 내역 조회 API 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
@@ -1,8 +1,10 @@
 package com.umc.TheGoods.converter.cart;
 
+import com.umc.TheGoods.converter.item.ItemConverter;
 import com.umc.TheGoods.domain.order.Cart;
 import com.umc.TheGoods.domain.order.CartDetail;
 import com.umc.TheGoods.web.dto.cart.CartResponseDTO;
+import com.umc.TheGoods.web.dto.item.ItemResponseDTO;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,10 +33,16 @@ public class CartConverter {
         List<CartResponseDTO.cartDetailViewDTO> cartDetailViewDTOList = cart.getCartDetailList().stream()
                 .map(CartConverter::toCartDetailViewDTO).collect(Collectors.toList());
 
+        List<ItemResponseDTO.ItemImgResponseDTO> itemImgResponseDTOList = cart.getItem().getItemImgList().stream()
+                .map(ItemConverter::getItemImgDTO)
+                .filter(ItemResponseDTO.ItemImgResponseDTO::getIsThumbNail).collect(Collectors.toList());
+
+        String itemImgUrl = itemImgResponseDTOList.get(0).getItemImgUrl();
+
         return CartResponseDTO.cartViewDTO.builder()
                 .sellerName(cart.getItem().getMember().getNickname())
                 .itemName(cart.getItem().getName())
-                .itemImg("img url") // item 썸네일 가져오는 메소드 필요
+                .itemImg(itemImgUrl)
                 .deliveryFee(cart.getItem().getDeliveryFee())
                 .cartDetailViewDTOList(cartDetailViewDTOList)
                 .build();

--- a/src/main/java/com/umc/TheGoods/converter/order/OrderConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/order/OrderConverter.java
@@ -1,10 +1,12 @@
 package com.umc.TheGoods.converter.order;
 
+import com.umc.TheGoods.converter.item.ItemConverter;
 import com.umc.TheGoods.domain.enums.OrderStatus;
 import com.umc.TheGoods.domain.order.OrderDetail;
 import com.umc.TheGoods.domain.order.OrderItem;
 import com.umc.TheGoods.domain.order.Orders;
 import com.umc.TheGoods.domain.types.PayType;
+import com.umc.TheGoods.web.dto.item.ItemResponseDTO;
 import com.umc.TheGoods.web.dto.order.OrderRequestDTO;
 import com.umc.TheGoods.web.dto.order.OrderResponseDTO;
 import org.springframework.data.domain.Page;
@@ -69,13 +71,20 @@ public class OrderConverter {
     }
 
     public static OrderResponseDTO.OrderItemPreViewDTO toOrderItemPreViewDTO(OrderItem orderItem) {
+
+        List<ItemResponseDTO.ItemImgResponseDTO> itemImgResponseDTOList = orderItem.getItem().getItemImgList().stream()
+                .map(ItemConverter::getItemImgDTO)
+                .filter(ItemResponseDTO.ItemImgResponseDTO::getIsThumbNail).collect(Collectors.toList());
+
+        String itemImgUrl = itemImgResponseDTOList.get(0).getItemImgUrl();
+
         return OrderResponseDTO.OrderItemPreViewDTO.builder()
                 .orderItemId((orderItem.getId()))
                 .orderStatus(orderItem.getStatus())
                 .orderDateTime(orderItem.getCreatedAt())
                 .itemName(orderItem.getItem().getName())
                 .optionString(toOptionString(orderItem))
-                .imgUrl("img url") // 추후 썸네일 이미지 가져오는 메소드 통해 값 입력 필요
+                .imgUrl(itemImgUrl)
                 .price(orderItem.getTotalPrice())
                 .build();
     }
@@ -95,10 +104,17 @@ public class OrderConverter {
     }
 
     public static OrderResponseDTO.OrderItemViewDTO toOrderItemViewDTO(OrderItem orderItem) {
+
+        List<ItemResponseDTO.ItemImgResponseDTO> itemImgResponseDTOList = orderItem.getItem().getItemImgList().stream()
+                .map(ItemConverter::getItemImgDTO)
+                .filter(ItemResponseDTO.ItemImgResponseDTO::getIsThumbNail).collect(Collectors.toList());
+
+        String itemImgUrl = itemImgResponseDTOList.get(0).getItemImgUrl();
+
         return OrderResponseDTO.OrderItemViewDTO.builder()
                 .ordersId(orderItem.getOrders().getId())
                 .orderItemId(orderItem.getId())
-                .imgUrl("img url")
+                .imgUrl(itemImgUrl)
                 .itemName(orderItem.getItem().getName())
                 .optionString(toOptionString(orderItem))
                 .orderStatus(orderItem.getStatus())


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
장바구니 내역 조회 API의 응답에 이미지 url 포함하도록 수정
주문 내역 조회 API의 응답에 이미지 url 포함하도록 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 장바구니 내역 조회 API의 응답에 이미지 url 포함하도록 수정
- 주문 내역 조회 API의 응답에 이미지 url 포함하도록 수정

## ⏳ 작업 내용

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

