### PR TITLE
:recycle: Refactor: 상품 데이터 세팅 API 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/domain/images/ProfileImg.java
+++ b/src/main/java/com/umc/TheGoods/domain/images/ProfileImg.java
@@ -23,4 +23,9 @@ public class ProfileImg {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void setMember(Member member) {
+        this.member = member;
+        member.setProfileImg(this);
+    }
 }

--- a/src/main/java/com/umc/TheGoods/domain/member/Member.java
+++ b/src/main/java/com/umc/TheGoods/domain/member/Member.java
@@ -204,5 +204,7 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Payment> paymentList = new ArrayList<>();
 
-
+    public void setProfileImg(ProfileImg profileImg) {
+        this.profileImg = profileImg;
+    }
 }

--- a/src/main/java/com/umc/TheGoods/repository/item/CategoryTagRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/item/CategoryTagRepository.java
@@ -1,7 +1,13 @@
 package com.umc.TheGoods.repository.item;
 
+import com.umc.TheGoods.domain.item.Category;
+import com.umc.TheGoods.domain.item.Tag;
 import com.umc.TheGoods.domain.mapping.Tag.CategoryTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryTagRepository extends JpaRepository<CategoryTag, Long> {
+
+    Optional<CategoryTag> findByCategoryAndTag(Category category, Tag tag);
 }

--- a/src/main/java/com/umc/TheGoods/test/TestController.java
+++ b/src/main/java/com/umc/TheGoods/test/TestController.java
@@ -4,11 +4,9 @@ import com.umc.TheGoods.apiPayload.ApiResponse;
 import com.umc.TheGoods.domain.enums.Gender;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.member.Member;
-import com.umc.TheGoods.service.ItemService.ItemCommandService;
 import com.umc.TheGoods.service.MemberService.MemberCommandServiceImpl;
 import com.umc.TheGoods.service.MemberService.MemberQueryService;
 import com.umc.TheGoods.test.service.TestCommandService;
-import com.umc.TheGoods.web.dto.item.ItemRequestDTO;
 import com.umc.TheGoods.web.dto.member.MemberRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -31,40 +28,11 @@ public class TestController {
 
     private final MemberCommandServiceImpl memberCommandService;
     private final MemberQueryService memberQueryService;
-    private final ItemCommandService itemCommandService;
     private final TestCommandService testCommandService;
 
 
-//    @PostMapping(value = "/setItemData")
-//    public ApiResponse<TestResponseDTO.addItemDTO> setItemData(
-//            @RequestPart(value = "request") @Valid TestRequestDTO.setItemDTO request,
-//            @RequestPart(value = "itemThumbnail") MultipartFile itemThumbnail,
-//            @RequestPart(value = "itemImgList") List<MultipartFile> itemImgList,
-//            @RequestPart(value = "sellerProfile") MultipartFile sellerProfile
-//    ) {
-//
-//        // 회원 가입
-//        Member member = null;
-//        if (memberQueryService.findMemberByNickname(request.getSellerName()).isEmpty()) { // 해당 판매자 회원이 없으면
-//            // 회원 가입
-//            List<Boolean> termAgreeList = new ArrayList<>();
-//            termAgreeList.add(true);
-//            List<Long> memberCategoryList = new ArrayList<>();
-//            memberCategoryList.add(1L);
-//            TestRequestDTO.setMemberDTO sellerDTO = new TestRequestDTO.setMemberDTO(request.sellerName, request.itemUuid, termAgreeList, memberCategoryList);
-//            member = testCommandService.addMember(sellerDTO, sellerProfile);
-//        } else {
-//            member = memberQueryService.findMemberByNickname(request.getSellerName()).get();
-//        }
-//
-//        // 상품 등록
-//        Item item = testCommandService.addItem(member, request, itemThumbnail, itemImgList);
-//
-//        return ApiResponse.onSuccess(TestConverter.toAddItemDTO(item));
-//    }
-
-
     @PostMapping(value = "/setItemData")
+    @Operation(summary = "상품 크롤링 데이터 추가 API", description = "크롤링된 상품 데이터를 db에 저장하는 API 입니다. Swagger에서는 테스트가 불가능합니다. ")
     public ApiResponse<TestResponseDTO.addItemDTO> setItemData(
             @RequestPart(value = "request") @Valid TestRequestDTO.setItemDTO request,
             @RequestPart(value = "itemThumbnail") MultipartFile itemThumbnail,
@@ -79,11 +47,21 @@ public class TestController {
         if (member.isEmpty()) { // 해당 판매자 회원이 없으면
             log.info("=========================== 닉네임으로 회원 찾을 수 없음 ================================");
 
-            // 회원 가입
+            // 약관 동의 리스트 설정
             List<Boolean> termAgreeList = new ArrayList<>();
             termAgreeList.add(true);
+            termAgreeList.add(true);
+            termAgreeList.add(true);
+
+
+            // 선호 카테고리 랜덤 설정
             List<Long> memberCategoryList = new ArrayList<>();
-            memberCategoryList.add(1L);
+            long leftLimit = 1L;
+            long rightLimit = 6L;
+            long generatedLong = leftLimit + (long) (Math.random() * (rightLimit - leftLimit));
+            memberCategoryList.add(generatedLong);
+
+            // 회원 가입
             TestRequestDTO.setMemberDTO sellerDTO = new TestRequestDTO.setMemberDTO(request.sellerName, request.itemUuid, termAgreeList, memberCategoryList);
             seller = testCommandService.addMember(sellerDTO, sellerProfile);
         } else {
@@ -105,14 +83,13 @@ public class TestController {
     }
 
     @GetMapping("/setTestData")
-    @Operation(summary = "테스트용 데이터 생성 API", description = "회원, 상품, 상품 옵션 dummy data를 생성해 db에 저장합니다. category, term, tag 데이터는 db에 수동으로 입력해야 합니다. (id가 1인 category, term, tag 데이터가 필요합니다.) \n\n " +
+    @Operation(summary = "테스트용 데이터 생성 API", description = "회원 dummy data를 생성해 db에 저장합니다. category, term, tag 데이터는 db에 수동으로 입력해야 합니다. (id가 1인 category, term, tag 데이터가 필요합니다.) \n\n " +
             "category 생성 sql: INSERT INTO category(name,created_at,updated_at) VALUES ('아이돌',now(),now());\n\n" +
             "tag 생성 sql: INSERT INTO tag(name,created_at,updated_at) VALUES ('포카',now(),now());\n\n" +
             "term 생성 sql: INSERT INTO term(title,created_at,updated_at) VALUES ('정보 이용 동의',now(),now());\n\n" +
             "생성된 회원 계정은 아래와 같습니다.\n\n" +
-            "1. 구매자 계정 - email: testbuyer@gmail.com, password: 12345678\n\n" +
-            "2. 판매자 계정 - email: testseller@gmail.com, password: 12345678\n\n" +
-            "3. 비로그인 주문용 계정 - email: nologinuser@gmail.com, password:12345678")
+            "1. 구매자 계정 - email: test@gmail.com, password: 12345678\n\n" +
+            "2. 비로그인 주문용 계정 - email: nologinuser@gmail.com, password:12345678")
     public String setTestData() {
 
         // 회원 가입
@@ -122,54 +99,13 @@ public class TestController {
         List<Long> memberCategoryList = new ArrayList<>();
         memberCategoryList.add(1L);
 
-        MemberRequestDTO.JoinDTO joinBuyerDTO = new MemberRequestDTO.JoinDTO("test_buyer", "12345678", "testbuyer@gmail.com", date, "01012345678", Gender.MALE, termAgreeList, memberCategoryList);
-        MemberRequestDTO.JoinDTO joinSellerDTO = new MemberRequestDTO.JoinDTO("test_seller", "12345678", "testseller@gmail.com", date, "01012341234", Gender.MALE, termAgreeList, memberCategoryList);
+        MemberRequestDTO.JoinDTO joinBuyerDTO = new MemberRequestDTO.JoinDTO("구매자 테스트 계정", "12345678", "test@gmail.com", date, "01012345678", Gender.MALE, termAgreeList, memberCategoryList);
         MemberRequestDTO.JoinDTO noLoginUserDTO = new MemberRequestDTO.JoinDTO("no_login_user", "12345678", "nologinuser@gmail.com", date, "01087654321", Gender.MALE, termAgreeList, memberCategoryList);
 
 
         memberCommandService.join(joinBuyerDTO);
-        memberCommandService.join(joinSellerDTO);
         memberCommandService.join(noLoginUserDTO);
 
-        // item 및 itemOption 등록
-        Member member = memberQueryService.findMemberById(2L).get();
-        LocalDate startDate = LocalDate.now();
-        LocalDate endDate = LocalDate.of(2024, 3, 1);
-
-        ItemRequestDTO.itemImgDTO itemImgDTO = new ItemRequestDTO.itemImgDTO(false, "img url");
-        List<ItemRequestDTO.itemImgDTO> itemImgDTOList = new ArrayList<>();
-        itemImgDTOList.add(itemImgDTO);
-
-        List<Long> tagList = new ArrayList<>();
-        tagList.add(1L);
-
-        // 뉴진스 포카 item 등록
-//        ItemRequestDTO.itemOptionDTO itemOptionDTO1 = new ItemRequestDTO.itemOptionDTO("해린 포카", 1000L, 20);
-//        ItemRequestDTO.itemOptionDTO itemOptionDTO2 = new ItemRequestDTO.itemOptionDTO("민지 포카", 2000L, 20);
-//        ItemRequestDTO.itemOptionDTO itemOptionDTO3 = new ItemRequestDTO.itemOptionDTO("하니 포카", 3000L, 20);
-//        List<ItemRequestDTO.itemOptionDTO> itemOptionDTOList1 = new ArrayList<>();
-//        itemOptionDTOList1.add(itemOptionDTO1);
-//        itemOptionDTOList1.add(itemOptionDTO2);
-//        itemOptionDTOList1.add(itemOptionDTO3);
-//
-//        ItemRequestDTO.UploadItemDTO uploadItemDTO1 = new ItemRequestDTO.UploadItemDTO("뉴진스 포카", "ONSALE", null, null, 3000, 1, 3, "뉴진스 포카입니다.", false, startDate, endDate, 0L, 0L, 0L, 1L, itemImgDTOList, itemOptionDTOList1, tagList);
-//        //itemCommandService.uploadItem(member, uploadItemDTO1);
-//
-//        // 아이브 포카 item 등록
-//        ItemRequestDTO.itemOptionDTO itemOptionDTO4 = new ItemRequestDTO.itemOptionDTO("원영 포카", 1000L, 20);
-//        ItemRequestDTO.itemOptionDTO itemOptionDTO5 = new ItemRequestDTO.itemOptionDTO("유진 포카", 2000L, 20);
-//        List<ItemRequestDTO.itemOptionDTO> itemOptionDTOList2 = new ArrayList<>();
-//        itemOptionDTOList2.add(itemOptionDTO4);
-//        itemOptionDTOList2.add(itemOptionDTO5);
-//
-//        ItemRequestDTO.UploadItemDTO uploadItemDTO2 = new ItemRequestDTO.UploadItemDTO("아이브 포카", "ONSALE", null, null, 2000, 1, 3, "아이브 포카입니다.", false, startDate, endDate, 0L, 0L, 0L, 1L, itemImgDTOList, itemOptionDTOList2, tagList);
-//        //itemCommandService.uploadItem(member, uploadItemDTO2);
-//
-//        // 카리나 포카 item 등록 (단일 상품)
-//        ItemRequestDTO.UploadItemDTO uploadItemDTO3 = new ItemRequestDTO.UploadItemDTO("카리나 포카", "ONSALE", 100, 3000L, 3000, 1, 3, "카리나 포카입니다.", false, startDate, endDate, 0L, 0L, 0L, 1L, itemImgDTOList, new ArrayList<>(), tagList);
-//        //itemCommandService.uploadItem(member, uploadItemDTO3);
-
-
-        return "Setting Test Data";
+        return " Test Data Set Completed";
     }
 }

--- a/src/main/java/com/umc/TheGoods/test/TestConverter.java
+++ b/src/main/java/com/umc/TheGoods/test/TestConverter.java
@@ -4,6 +4,7 @@ import com.umc.TheGoods.domain.enums.Gender;
 import com.umc.TheGoods.domain.enums.ItemStatus;
 import com.umc.TheGoods.domain.enums.MemberRole;
 import com.umc.TheGoods.domain.images.ItemImg;
+import com.umc.TheGoods.domain.images.ProfileImg;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.Tag;
 import com.umc.TheGoods.domain.mapping.Tag.CategoryTag;
@@ -35,6 +36,12 @@ public class TestConverter {
                 .itemList(new ArrayList<>())
                 .build();
 
+    }
+
+    public static ProfileImg toProfileImg(String imgUrl) {
+        return ProfileImg.builder()
+                .url(imgUrl)
+                .build();
     }
 
     public static Item toTestItem(TestRequestDTO.setItemDTO request) {
@@ -80,6 +87,7 @@ public class TestConverter {
                 .dibsCount(request.dibsCount)
                 .viewCount(request.viewCount)
                 .salesCount(request.salesCount)
+                .tagsCount(0)
                 .status(ItemStatus.ONSALE)
                 .price(request.getPrice())
                 .stock(request.getStock())


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
상품 데이터 세팅 API 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 크롤링된 상품 데이터들 중 옵션이 10개 이하, 상품 이미지 개수가 20개 이하인 데이터만 필터링
- 상품 등록 시, 카테고리-태그를 다대다 관계로 저장하도록 변경
- 회원-회원프로필 간의 연관관계 설정

## ⏳ 작업 내용
- [ ] 상품 데이터 세팅 API 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

