### PR TITLE
[Bug/166] 장바구니 상품 삭제 API 로직 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -42,6 +42,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_CART_OWNER(HttpStatus.BAD_REQUEST, "CART4002", "본인의 장바구니 내역이 아닙니다. 접근할 수 없습니다."),
     CART_DETAIL_FOUND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CART4003", "단일 상품의 장바구니 상세 내역을 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
     CART_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "CART4004", "해당 장바구니 상세 내역을 찾을 수 없습니다"),
+    DELETE_CART_DETAIL_FAILED(HttpStatus.BAD_REQUEST, "CART4005", "장바구니 상세 내역을 삭제할 수 없습니다."),
 
     // test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트"),
@@ -61,11 +62,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //JWT
 
-    JWT_BAD_REQUEST(HttpStatus.UNAUTHORIZED, "JWT4001","잘못된 JWT 서명입니다."),
-    JWT_ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT4002","액세스 토큰이 만료되었습니다."),
-    JWT_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT4003","리프레시 토큰이 만료되었습니다. 다시 로그인하시기 바랍니다."),
-    JWT_UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT4004","지원하지 않는 JWT 토큰입니다."),
-    JWT_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT4005","유효한 JWT 토큰이 없습니다."),
+    JWT_BAD_REQUEST(HttpStatus.UNAUTHORIZED, "JWT4001", "잘못된 JWT 서명입니다."),
+    JWT_ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT4002", "액세스 토큰이 만료되었습니다."),
+    JWT_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT4003", "리프레시 토큰이 만료되었습니다. 다시 로그인하시기 바랍니다."),
+    JWT_UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT4004", "지원하지 않는 JWT 토큰입니다."),
+    JWT_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT4005", "유효한 JWT 토큰이 없습니다."),
 
     //Category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "해당 카테고리가 존재하지 않습니다"),

--- a/src/main/java/com/umc/TheGoods/domain/order/Cart.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/Cart.java
@@ -52,12 +52,14 @@ public class Cart extends BaseDateTimeEntity {
     public void detachMember() {
         if (this.member != null) {
             this.member.getCartList().remove(this);
+            this.member = null;
         }
     }
 
     public void detachItem() {
         if (this.item != null) {
             this.item.getItemCartList().remove(this);
+            this.item = null;
         }
     }
 

--- a/src/main/java/com/umc/TheGoods/domain/order/Cart.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/Cart.java
@@ -49,23 +49,4 @@ public class Cart extends BaseDateTimeEntity {
         item.getItemCartList().add(this);
     }
 
-    public void detachMember() {
-        if (this.member != null) {
-            this.member.getCartList().remove(this);
-            this.member = null;
-        }
-    }
-
-    public void detachItem() {
-        if (this.item != null) {
-            this.item.getItemCartList().remove(this);
-            this.item = null;
-        }
-    }
-
-    public void detachCartDetail() {
-        this.cartDetailList = new ArrayList<>();
-    }
-
-
 }

--- a/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
+++ b/src/main/java/com/umc/TheGoods/domain/order/CartDetail.java
@@ -40,12 +40,14 @@ public class CartDetail extends BaseDateTimeEntity {
     public void detachCart() {
         if (this.cart != null) {
             this.cart.getCartDetailList().remove(this);
+            this.cart = null;
         }
     }
 
     public void detachItemOption() {
         if (this.itemOption != null) {
             this.itemOption.getCartDetailList().remove(this);
+            this.itemOption = null;
         }
     }
 

--- a/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
+++ b/src/main/java/com/umc/TheGoods/repository/cart/CartRepository.java
@@ -4,9 +4,6 @@ import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.order.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +14,4 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     List<Cart> findAllByMember(Member member);
 
-    @Modifying
-    @Query("delete from Cart c where c.id=:id")
-    void deleteCartById(@Param("id") Long cartId);
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartCommandServiceImpl.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -173,37 +172,45 @@ public class CartCommandServiceImpl implements CartCommandService {
     @Override
     public void deleteCartDetail(CartRequestDTO.cartDetailDeleteDTO request, Member member) {
 
-        List<Long> deleteCartId = new ArrayList<>();
+        Cart firstCart = cartDetailRepository.findById(request.getCartDetailIdList().get(0)).orElseThrow(() -> new OrderHandler(ErrorStatus.CART_DETAIL_NOT_FOUND)).getCart();
 
-        request.getCartDetailIdList().forEach(cartDetailId -> {
-
+        // request의 cartDetailIdList로 cartDetailList 생성
+        List<CartDetail> cartDetailList = request.getCartDetailIdList().stream().map(cartDetailId -> {
             CartDetail cartDetail = cartDetailRepository.findById(cartDetailId).orElseThrow(() -> new OrderHandler(ErrorStatus.CART_DETAIL_NOT_FOUND));
 
-            Cart cart = cartDetail.getCart();
-
             // 해당 cart 내역을 수정할 권한 있는지 검증
-            if (!cart.getMember().equals(member)) {
+            if (!cartDetail.getCart().getMember().equals(member)) {
                 throw new OrderHandler(ErrorStatus.NOT_CART_OWNER);
             }
-            cartDetail.detachCart();
-            cartDetail.detachItemOption();
 
-            cartDetailRepository.deleteById(cartDetail.getId());
-
-            //cartDetailRepository.flush();
-
-            // 장바구니 상품의 마지막 옵션 내역을 삭제한 경우: 장바구니 상품 내역도 삭제
-            if (cart.getCartDetailList().isEmpty()) {
-                deleteCartId.add(cart.getId());
+            // cartDetailId가 모두 동일한 장바구니 내역에 대한 담은 옵션이 맞는지 검증
+            if (!firstCart.equals(cartDetail.getCart())) {
+                throw new OrderHandler(ErrorStatus.DELETE_CART_DETAIL_FAILED);
             }
-        });
+            return cartDetail;
+        }).collect(Collectors.toList());
 
 
-        deleteCartId.forEach(cartId -> {
-            log.info(" ===================== deleteSingleCart ========================");
-            deleteSingleCart(cartId);
-        });
+        // 해당 장바구니 상품의 모든 담은 옵션 list 조회
+        List<CartDetail> originCartDetailList = firstCart.getCartDetailList();
 
+        List<Long> cartDetailIdList = cartDetailList.stream().map(cartDetail -> {
+            return cartDetail.getId();
+        }).collect(Collectors.toList());
+        List<Long> originCartDetailIdList = originCartDetailList.stream().map(originCartDetail -> {
+            return originCartDetail.getId();
+        }).collect(Collectors.toList());
+
+        // 장바구니 삭제
+        if (isEqualCartDetailList(cartDetailIdList, originCartDetailIdList)) { // 해당 장바구니 상품 내역의 담은 옵션 모두를 삭제하는 경우
+            cartRepository.deleteById(firstCart.getId());
+        } else { // 해당 장바구니 생품 내역의 담은 옵션 일부만 삭제하는 경우
+            cartDetailList.forEach(cartDetail -> {
+                cartDetail.detachCart();
+                cartDetail.detachItemOption();
+                cartDetailRepository.deleteById(cartDetail.getId());
+            });
+        }
     }
 
     @Override
@@ -216,34 +223,23 @@ public class CartCommandServiceImpl implements CartCommandService {
                 throw new OrderHandler(ErrorStatus.NOT_CART_OWNER);
             }
 
-            // 해당 장바구니 상품의 담은 옵션 삭제
-            List<CartDetail> cartDetailList = cartDetailRepository.findAllByCart(cart);
-            cartDetailList.forEach(cartDetail -> {
-                log.info("===== cartDetailId: {}", cartDetail.getId());
-                cartDetail.detachCart();
-                cartDetail.detachItemOption();
-
-                cartDetailRepository.deleteById(cartDetail.getId());
-            });
-
-
-            // 해당 장바구니 상품 내역 삭제
-            cart.detachMember();
-            cart.detachItem();
-            cart.detachCartDetail();
             cartRepository.deleteById(cart.getId());
         });
 
     }
 
-    private void deleteSingleCart(Long cartId) {
-        Cart cart = cartRepository.findById(cartId).orElseThrow(() -> new OrderHandler(ErrorStatus.CART_NOT_FOUND));
+    private boolean isEqualCartDetailList(List<Long> x, List<Long> y) {
+        if (x == null) {
+            return y == null;
+        }
 
-        log.info("========================= delete query please=========================");
-        // 해당 장바구니 상품 내역 삭제
-        cart.detachMember();
-        cart.detachItem();
-        cart.detachCartDetail();
-        cartRepository.deleteById(cart.getId());
+        if (x.size() != y.size()) {
+            return false;
+        }
+
+        x = x.stream().sorted().collect(Collectors.toList());
+        y = y.stream().sorted().collect(Collectors.toList());
+
+        return x.equals(y);
     }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
jpa delete 쿼리가 실행되지 않는 문제 해결을 위해 deleteCart, deleteCartDetail 메소드의 로직을 수정했습니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 기존 jpql로 delete 쿼리 강제 실행했던 코드 제거
- deleteCart 서비스 메소드 수정
  (기존 로직) cartDetail delete -> cart delete 
  (수정 후 로직) cart delete 메소드만 호출하고 cartDetail은 cascade로 자동 삭제되도록 변경
- deleteCartDetail 서비스 메소드 수정
  (기존 로직) cartDetail delete -> 해당 cart의 모든 cartDetail이 삭제된 경우 cart entity delete
  (수정 후 로직) 요청으로 보낸 cartDetail list와 기존에 담아둔 cart의 cartDetail list 비교 -> 해당 cart의 모든 cartDetail을 삭제하고자 한다면 cart delete 메소드만 호출하고 cartDetail은 cascade로 자동 삭제, 일부 cartDetail만을 삭제하고자 한다면 cartDetail 개별 delete

## ⏳ 작업 내용
- [x] jpql 코드 제거
- [x] deleteCart, deleteCartDetail 로직 수정
- [x] ErrorStatus 추가
- [x] Cart 엔티티 내 불필요한 메소드 제거

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

