### PR TITLE
:recycle: Refactor: 장바구니 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/cart/CartConverter.java
@@ -1,11 +1,14 @@
 package com.umc.TheGoods.converter.cart;
 
+import com.umc.TheGoods.converter.item.ItemConverter;
 import com.umc.TheGoods.domain.enums.CartStatus;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
 import com.umc.TheGoods.domain.order.Cart;
 import com.umc.TheGoods.web.dto.cart.CartResponseDTO;
+import com.umc.TheGoods.web.dto.item.ItemResponseDTO;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,58 +31,63 @@ public class CartConverter {
     }
 
 
-//    public static CartResponseDTO.cartViewListDTO toCartViewListDTO(List<Cart> cartList) {
-//
-//        List<CartResponseDTO.cartViewDTO> cartViewDTOList = new ArrayList<>();
-//
-//        cartList.forEach(cart -> {
-//            if (!cartViewDTOList.isEmpty()) {
-//                CartResponseDTO.cartViewDTO cartViewDTO = cartViewDTOList.get(cartViewDTOList.size() - 1);
-//                if (cartViewDTO.getItemId().equals(cart.getItem().getId())) { // cartViewDTO 내의 cartOptionViewDTO 추가
-//
-//                } else { // 세로운 cartViewDTO 추가
-//                    CartResponseDTO.cartOptionViewDTO cartOptionViewDTO = toCartOptionViewDTO(cart);
-//                }
-//            }
-//
-//        });
-//
-//        return CartResponseDTO.cartViewListDTO.builder()
-//                .cartViewDTOList(cartList.stream().map(CartConverter::toCartViewDTO).collect(Collectors.toList()))
-//                .build();
-//    }
+    public static CartResponseDTO.cartViewListDTO toCartViewListDTO(List<Cart> cartList) {
 
-    //    public static CartResponseDTO.cartViewDTO toCartViewDTO(Cart cart) {
-//        List<CartResponseDTO.cartDetailViewDTO> cartDetailViewDTOList = cart.getCartDetailList().stream()
-//                .map(CartConverter::toCartDetailViewDTO).collect(Collectors.toList());
-//
-//        List<ItemResponseDTO.ItemImgResponseDTO> itemImgResponseDTOList = cart.getItem().getItemImgList().stream()
-//                .map(ItemConverter::getItemImgDTO)
-//                .filter(ItemResponseDTO.ItemImgResponseDTO::getIsThumbNail).collect(Collectors.toList());
-//
-//        String itemImgUrl = itemImgResponseDTOList.get(0).getItemImgUrl();
-//
-//        return CartResponseDTO.cartViewDTO.builder()
-//                .cartId(cart.getId())
-//                .sellerName(cart.getItem().getMember().getNickname())
-//                .itemId(cart.getItem().getId())
-//                .itemName(cart.getItem().getName())
-//                .itemImg(itemImgUrl)
-//                .deliveryFee(cart.getItem().getDeliveryFee())
-//                .cartDetailViewDTOList(cartDetailViewDTOList)
-//                .build();
-//    }
-//
-//    public static CartResponseDTO.cartOptionViewDTO toCartOptionViewDTO(Cart cart) {
-//        return CartResponseDTO.cartOptionViewDTO.builder()
-//                .cartId(cart.getId())
-//                .optionId(cart.getItemOption() == null ? null : cart.getItemOption().getId())
-//                .optionName(cart.getItemOption() == null ? null : cart.getItemOption().getName()) // 옵션이 있는 경우에만 옵션 이름 설정
-//                .price(cart.getItemOption() == null ? cart.getItem().getPrice() : cart.getItemOption().getPrice())
-//                .amount(cart.getAmount())
-//                .build();
-//    }
-//
+        List<CartResponseDTO.cartViewDTO> cartViewDTOList = new ArrayList<>();
+
+        cartList.forEach(cart -> {
+            if (!cartViewDTOList.isEmpty()) {
+                // cartViewDTOList의 마지막 DTO와 cart를 비교해 cartViewDTO를 새로 추가할지, 기존 cartViewDTO 내에 cartOptionViewDTO만 추가할지 결정
+                CartResponseDTO.cartViewDTO cartViewDTO = cartViewDTOList.get(cartViewDTOList.size() - 1);
+                if (cartViewDTO.getItemId().equals(cart.getItem().getId())) { // cartViewDTO 내의 cartOptionViewDTO 추가
+                    cartViewDTO.addCartOptionViewDTO(toCartOptionViewDTO(cart));
+                } else { // cartViewDTOList에 새로운 cartViewDTO 생성 및 추가
+                    CartResponseDTO.cartViewDTO newCartViewDTO = toCartViewDTO(cart);
+                    cartViewDTOList.add(newCartViewDTO);
+                }
+            } else { // 첫 cartViewDTO 추가
+                CartResponseDTO.cartViewDTO newCartViewDTO = toCartViewDTO(cart);
+                cartViewDTOList.add(newCartViewDTO);
+            }
+
+        });
+
+        return CartResponseDTO.cartViewListDTO.builder()
+                .cartViewDTOList(cartViewDTOList)
+                .build();
+    }
+
+    public static CartResponseDTO.cartViewDTO toCartViewDTO(Cart cart) {
+
+        List<CartResponseDTO.cartOptionViewDTO> cartOptionViewDTOList = new ArrayList<>();
+        cartOptionViewDTOList.add(toCartOptionViewDTO(cart));
+
+        List<ItemResponseDTO.ItemImgResponseDTO> itemImgResponseDTOList = cart.getItem().getItemImgList().stream()
+                .map(ItemConverter::getItemImgDTO)
+                .filter(ItemResponseDTO.ItemImgResponseDTO::getIsThumbNail).collect(Collectors.toList());
+
+        String itemImgUrl = itemImgResponseDTOList.get(0).getItemImgUrl();
+
+        return CartResponseDTO.cartViewDTO.builder()
+                .sellerName(cart.getItem().getMember().getNickname())
+                .itemId(cart.getItem().getId())
+                .itemName(cart.getItem().getName())
+                .itemImg(itemImgUrl)
+                .deliveryFee(cart.getItem().getDeliveryFee())
+                .cartOptionViewDTOList(cartOptionViewDTOList)
+                .build();
+    }
+
+    public static CartResponseDTO.cartOptionViewDTO toCartOptionViewDTO(Cart cart) {
+        return CartResponseDTO.cartOptionViewDTO.builder()
+                .cartId(cart.getId())
+                .optionId(cart.getItemOption() == null ? null : cart.getItemOption().getId())
+                .optionName(cart.getItemOption() == null ? null : cart.getItemOption().getName()) // 옵션이 있는 경우에만 옵션 이름 설정
+                .price(cart.getItemOption() == null ? cart.getItem().getPrice() : cart.getItemOption().getPrice())
+                .amount(cart.getAmount())
+                .build();
+    }
+
     public static CartResponseDTO.cartStockDTO toCartStockDTO(List<Cart> cartList) {
 
         List<CartResponseDTO.cartOptionStockDTO> cartOptionStockDTOList = cartList.stream()

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartQueryService.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartQueryService.java
@@ -10,4 +10,6 @@ public interface CartQueryService {
     boolean isExistCart(Long cartId);
 
     List<Cart> getCartsByItem(Long itemId, Member member);
+
+    List<Cart> getCartsByMember(Member member);
 }

--- a/src/main/java/com/umc/TheGoods/service/CartService/CartQueryServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/CartService/CartQueryServiceImpl.java
@@ -27,5 +27,10 @@ public class CartQueryServiceImpl implements CartQueryService {
         return cartRepository.findAllByMemberAndItemIdAndCartStatus(member, itemId, CartStatus.ACTIVE);
     }
 
+    @Override
+    public List<Cart> getCartsByMember(Member member) {
+        return cartRepository.findAllByMemberAndCartStatusOrderByItemIdAsc(member, CartStatus.ACTIVE);
+    }
+
 
 }

--- a/src/main/java/com/umc/TheGoods/web/controller/CartController.java
+++ b/src/main/java/com/umc/TheGoods/web/controller/CartController.java
@@ -57,24 +57,24 @@ public class CartController {
         return ApiResponse.onSuccess("장바구니 담기 성공");
     }
 
-//    @GetMapping
-//    @Operation(summary = "나의 장바구니 목록 조회 API", description = "나의 장바구니 목록을 조회하는 API 입니다. (구매자 회원용)")
-//    @ApiResponses(value = {
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-//    })
-//    public ApiResponse<CartResponseDTO.cartViewListDTO> cartView(Authentication authentication) {
-//        // 비회원인 경우 처리 불가
-//        if (authentication == null) {
-//            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
-//        }
-//
-//        // request에서 member id 추출해 Member 엔티티 찾기
-//        Member member = memberQueryService.findMemberById(Long.valueOf(authentication.getName().toString())).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-//
-//        List<Cart> cartList = cartQueryService.getCartList(member);
-//
-//        return ApiResponse.onSuccess(CartConverter.toCartViewListDTO(cartList));
-//    }
+    @GetMapping
+    @Operation(summary = "나의 장바구니 목록 조회 API", description = "나의 장바구니 목록을 조회하는 API 입니다. (구매자 회원용)")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<CartResponseDTO.cartViewListDTO> cartView(Authentication authentication) {
+        // 비회원인 경우 처리 불가
+        if (authentication == null) {
+            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        // request에서 member id 추출해 Member 엔티티 찾기
+        Member member = memberQueryService.findMemberById(Long.valueOf(authentication.getName().toString())).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Cart> cartList = cartQueryService.getCartsByMember(member);
+
+        return ApiResponse.onSuccess(CartConverter.toCartViewListDTO(cartList));
+    }
 
     @PutMapping
     @Operation(summary = "장바구니 수량 수정 API", description = "해당 장바구니 내역의 담은 수량을 수정하는 API 입니다.")

--- a/src/main/java/com/umc/TheGoods/web/dto/cart/CartResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/cart/CartResponseDTO.java
@@ -22,21 +22,24 @@ public class CartResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class cartViewDTO {
-        Long cartId;
         String sellerName;
         Long itemId;
         String itemName;
         String itemImg;
         Integer deliveryFee;
-        List<cartDetailViewDTO> cartDetailViewDTOList;
+        List<cartOptionViewDTO> cartOptionViewDTOList;
+
+        public void addCartOptionViewDTO(cartOptionViewDTO cartOptionViewDTO) {
+            this.cartOptionViewDTOList.add(cartOptionViewDTO);
+        }
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class cartDetailViewDTO {
-        Long cartDetailId;
+    public static class cartOptionViewDTO {
+        Long cartId;
         Long optionId;
         String optionName;
         Long price;


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
장바구니 목록 조회 API 수정: 장바구니 엔티티에서 관리의 단위가 장바구니에 담은 상품 옵션으로 변경됨에 따라 DTO 및 converter 위주의 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- CartConverter, CartResponseDTO 변경
- service, controller 코드 추가

## ⏳ 작업 내용
- [ ] 

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

