### PR TITLE
:recycle: Refactor: jwt 유효기간 변경 및 Refresh Token 쿠키로 전송 기능 변경

### DIFF
--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_OWNER(HttpStatus.NOT_ACCEPTABLE, "MEMBER4011", "해당 회원이 아닙니다."),
     MEMBER_CONTACT_NOT_FOUND(HttpStatus.NOT_FOUND,"MEMBER4012", "연락 가능 시간을 조회할 수 없습니다."),
     MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "MEMBER4013", "중복된 이메일입니다."),
+    MEMBER_EMAIL_INCORRECT(HttpStatus.BAD_REQUEST, "MEMBER4014", "잘못된 이메일입니다."),
 
     //JWT
 

--- a/src/main/java/com/umc/TheGoods/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/TheGoods/apiPayload/code/status/SuccessStatus.java
@@ -22,6 +22,7 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_DECLARE_DELETE(HttpStatus.OK, "MEMBER2008", "신고 삭제 성공했습니다."),
     MEMBER_CONTACT_SUCCESS(HttpStatus.OK, "MEMBER2009", "연락가능 시간 변경 성공입니다."),
 
+
     //POST
     POST_FOLLOW_SUCCESS(HttpStatus.OK, "POST2001", "팔로우 성공입니다."),
     POST_DELETE_FOLLOW_SUCCESS(HttpStatus.OK, "POST2002", "팔로우 취소 성공입니다."),

--- a/src/main/java/com/umc/TheGoods/config/springSecurity/provider/TokenProvider.java
+++ b/src/main/java/com/umc/TheGoods/config/springSecurity/provider/TokenProvider.java
@@ -47,7 +47,7 @@ public class TokenProvider implements InitializingBean {
 
     public TokenProvider(@Value("${jwt.token.secret}") String secretKey) {
         this.secret = secretKey;
-        this.accessTokenValidityInMilliseconds = 1000 * 60 * 30L;
+        this.accessTokenValidityInMilliseconds = 1000 * 60 * 60* 6L;
     }
 
     @Override
@@ -82,7 +82,7 @@ public class TokenProvider implements InitializingBean {
 
     public String createRefreshToken(Collection<? extends GrantedAuthority> authorities) {
         //2주
-        long tokenValidTime = 60 * 60 * 24 * 14 * 1000L;
+        long tokenValidTime = 60 * 60 * 24 * 30 * 1000L;
         long now = (new Date()).getTime();
         Date validity = new Date(now + tokenValidTime);
 

--- a/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
+++ b/src/main/java/com/umc/TheGoods/converter/member/MemberConverter.java
@@ -67,9 +67,9 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponseDTO.NewTokenDTO toNewTokenDTO(String accessToken, String refreshToken) {
+    public static MemberResponseDTO.NewTokenDTO toNewTokenDTO(String accessToken, LocalDateTime time) {
         return MemberResponseDTO.NewTokenDTO.builder()
-                .refreshToken(refreshToken)
+                .accessExpireTime(time)
                 .accessToken(accessToken)
                 .build();
     }

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandService.java
@@ -2,6 +2,7 @@ package com.umc.TheGoods.service.MemberService;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.umc.TheGoods.apiPayload.ApiResponse;
 import com.umc.TheGoods.domain.member.Auth;
 import com.umc.TheGoods.domain.member.Member;
 import com.umc.TheGoods.domain.mypage.Account;
@@ -12,6 +13,8 @@ import com.umc.TheGoods.web.dto.member.MemberRequestDTO;
 import com.umc.TheGoods.web.dto.member.MemberResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletResponse;
+
 
 public interface MemberCommandService {
 
@@ -21,7 +24,7 @@ public interface MemberCommandService {
 
     Member join(MemberRequestDTO.JoinDTO request);
 
-    MemberResponseDTO.LoginResultDTO login(MemberRequestDTO.LoginDTO request);
+    MemberResponseDTO.LoginResultDTO login(MemberRequestDTO.LoginDTO request, HttpServletResponse response);
     void logout(String accessToken, Member member);
     String regenerateAccessToken(RefreshToken refreshToken);
 
@@ -39,13 +42,13 @@ public interface MemberCommandService {
 
     Boolean confirmEmailAuth(MemberRequestDTO.EmailAuthConfirmDTO request);
 
-    String emailAuthCreateJWT(MemberRequestDTO.EmailAuthConfirmDTO request);
+    MemberResponseDTO.LoginResultDTO emailAuthCreateJWT(MemberRequestDTO.EmailAuthConfirmDTO request, HttpServletResponse response);
 
     Boolean updatePassword(MemberRequestDTO.PasswordUpdateDTO request, Member member);
 
-    String kakaoAuth(String code);
+    ApiResponse<?> kakaoAuth(String code, HttpServletResponse response);
 
-    String naverAuth(String code, String state);
+    ApiResponse<?> naverAuth(String code, String state, HttpServletResponse response);
 
     Member profileModify(MultipartFile profile, String nickname, String introduce, Member member);
 

--- a/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/service/MemberService/MemberCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.TheGoods.service.MemberService;
 import antlr.Token;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.TheGoods.apiPayload.ApiResponse;
 import com.umc.TheGoods.apiPayload.code.status.ErrorStatus;
 import com.umc.TheGoods.apiPayload.exception.handler.MemberHandler;
 import com.umc.TheGoods.config.MailConfig;
@@ -44,6 +45,8 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -159,7 +162,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
      * @return
      */
     @Override
-    public MemberResponseDTO.LoginResultDTO login(MemberRequestDTO.LoginDTO request) {
+    public MemberResponseDTO.LoginResultDTO login(MemberRequestDTO.LoginDTO request, HttpServletResponse response) {
 
         //email 없음
         Member selectedMember = memberRepository.findByEmail(request.getEmail())
@@ -173,10 +176,20 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             throw new MemberHandler(ErrorStatus.MEMBER_PASSWORD_ERROR);
         }
 
+        // refresh 생성후 쿠키로 만들고 response 헤더에 담기
+        RefreshToken refreshToken = redisService.generateRefreshToken(request.getEmail());
+        Cookie cookie = new Cookie("refreshToken",refreshToken.getToken());
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        LocalDateTime accessExpireTime = currentDateTime.plusHours(6);
+
+
 
         return MemberResponseDTO.LoginResultDTO.builder()
                 .accessToken(redisService.saveLoginStatus(selectedMember.getId(), tokenProvider.createAccessToken(selectedMember.getId(), selectedMember.getMemberRole().toString() , request.getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")))))
-                .refreshToken(redisService.generateRefreshToken(request.getEmail()))
+                .accessExpireTime(accessExpireTime)
                 .build();
 
     }
@@ -382,7 +395,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public String emailAuthCreateJWT(MemberRequestDTO.EmailAuthConfirmDTO request) {
+    public MemberResponseDTO.LoginResultDTO emailAuthCreateJWT(MemberRequestDTO.EmailAuthConfirmDTO request, HttpServletResponse response) {
 
         Member member = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -390,7 +403,21 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         List<String> roles = new ArrayList<>();
         roles.add("ROLE_USER");
 
-        return tokenProvider.createAccessToken(member.getId(), member.getMemberRole().toString() , member.getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")));
+        // refresh 생성후 쿠키로 만들고 response 헤더에 담기
+        RefreshToken refreshToken = redisService.generateRefreshToken(request.getEmail());
+        Cookie cookie = new Cookie("refreshToken",refreshToken.getToken());
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        LocalDateTime accessExpireTime = currentDateTime.plusHours(6);
+
+        return MemberResponseDTO.LoginResultDTO.builder()
+                .accessToken(redisService.saveLoginStatus(member.getId(), tokenProvider.createAccessToken(member.getId(), member.getMemberRole().toString() , request.getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")))))
+                .accessExpireTime(accessExpireTime)
+                .build();
+
+
     }
 
     @Override
@@ -407,7 +434,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
-    public String kakaoAuth(String code) {
+    public ApiResponse<?> kakaoAuth(String code, HttpServletResponse res) {
 
         String jwt;
 
@@ -486,21 +513,40 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         Optional<Member> member = memberRepository.findByPhone(phone);
 
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        LocalDateTime accessExpireTime = currentDateTime.plusHours(6);
+
+
+
         if (member.isPresent()) {
 
             if(!this.checkDeregister(member.orElseThrow())){
                 throw new MemberHandler(ErrorStatus.MEMBER_INACTIVATE);
             }
-            return tokenProvider.createAccessToken(member.get().getId(), member.get().getMemberRole().toString() , member.get().getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")));
+
+            // refresh 생성후 쿠키로 만들고 response 헤더에 담기
+            RefreshToken refreshToken = redisService.generateRefreshToken(member.get().getEmail());
+            Cookie cookie = new Cookie("refreshToken",refreshToken.getToken());
+            cookie.setHttpOnly(true);
+            res.addCookie(cookie);
+
+
+            return ApiResponse.onSuccess(MemberResponseDTO.LoginResultDTO.builder()
+                    .accessToken(redisService.saveLoginStatus(member.get().getId(), tokenProvider.createAccessToken(member.get().getId(), member.get().getMemberRole().toString() , member.get().getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")))))
+                    .accessExpireTime(accessExpireTime)
+                    .build());
 
         }
 
-        return phone + kakaoProfile.getKakao_account().email;
+        return ApiResponse.onFailure("MEMBER401", "로그인 실패 회원가입 필요", MemberConverter.toSocialJoinResultDTO(phone, kakaoProfile.getKakao_account().email));
+
+
+
     }
 
     @Override
     @Transactional
-    public String naverAuth(String code, String state) {
+    public ApiResponse<?> naverAuth(String code, String state, HttpServletResponse res) {
         RestTemplate rt = new RestTemplate();
 
 
@@ -571,17 +617,31 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         Optional<Member> member = memberRepository.findByPhone(phone);
 
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        LocalDateTime accessExpireTime = currentDateTime.plusHours(6);
+
         if (member.isPresent()) {
 
             if(!this.checkDeregister(member.orElseThrow())){
                 throw new MemberHandler(ErrorStatus.MEMBER_INACTIVATE);
             }
 
-            return tokenProvider.createAccessToken(member.get().getId(), member.get().getMemberRole().toString() , member.get().getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")));
+            // refresh 생성후 쿠키로 만들고 response 헤더에 담기
+            RefreshToken refreshToken = redisService.generateRefreshToken(member.get().getEmail());
+            Cookie cookie = new Cookie("refreshToken",refreshToken.getToken());
+            cookie.setHttpOnly(true);
+            res.addCookie(cookie);
+
+            return ApiResponse.onSuccess(MemberResponseDTO.LoginResultDTO.builder()
+                    .accessToken(redisService.saveLoginStatus(member.get().getId(), tokenProvider.createAccessToken(member.get().getId(), member.get().getMemberRole().toString() , member.get().getEmail(), Arrays.asList(new SimpleGrantedAuthority("USER")))))
+                    .accessExpireTime(accessExpireTime)
+                    .build());
 
         }
 
-        return phone + naverProfile.getResponse().email;
+
+
+        return ApiResponse.onFailure("MEMBER401","로그인 실패 회원가입 필요",MemberConverter.toSocialJoinResultDTO(phone, naverProfile.getResponse().email));
     }
 
     @Override

--- a/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/umc/TheGoods/web/dto/member/MemberResponseDTO.java
@@ -44,7 +44,8 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     public static class LoginResultDTO {
         String accessToken;
-        RefreshToken refreshToken;
+        LocalDateTime accessExpireTime;
+
     }
 
     @Builder
@@ -241,7 +242,7 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     public static class NewTokenDTO{
         private String accessToken;
-        private String refreshToken;
+        private LocalDateTime accessExpireTime;
     }
 
 


### PR DESCRIPTION
# 🚀 개요
jwt 유효기간 변경 및 전송 방법 변경

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Access Token 유효기간 6시간, Refresh Token 유효기간 30일로 변경
- Refresh Token 쿠키로 전송

## ⏳ 작업 내용
- [x] 유효기간 변경
- [x] 전송 방식 변경
