### PR TITLE
[Feature/188] 테스트 데이터 등록용 API 수정

### DIFF
--- a/src/main/java/com/umc/TheGoods/config/springSecurity/SpringSecurityConfig.java
+++ b/src/main/java/com/umc/TheGoods/config/springSecurity/SpringSecurityConfig.java
@@ -53,8 +53,8 @@ public class SpringSecurityConfig {
                         "/api/members/password/update", "/api/members/phone/auth", "/api/members/phone/auth/**",
                         "/api/item/today", "/api/item/topsale", "/api/item/steady", "/api/count/tags/item",
                         "/api/delivery-date/item", "/api/item/main", "/api/item/{itemId}/related", "/api/order/api/nologin/order",
-                        "api/seller/item/{itemId}",
-                        "/api/setItemData"
+                        "/api/seller/item/{itemId}",
+                        "/api/setItemData", "/api/search/item"
                 );
     }
 

--- a/src/main/java/com/umc/TheGoods/config/springSecurity/SpringSecurityConfig.java
+++ b/src/main/java/com/umc/TheGoods/config/springSecurity/SpringSecurityConfig.java
@@ -26,7 +26,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SpringSecurityConfig {
 
 
-
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final JwtAuthenticationExceptionHandler exceptionFilter;
@@ -36,8 +35,9 @@ public class SpringSecurityConfig {
     private String secretKey;
 
     private final UrlBasedCorsConfigurationSource corsConfigurationSource;
+
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer(){
+    public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
                 .antMatchers(
                         "/favicon.ico",
@@ -48,13 +48,16 @@ public class SpringSecurityConfig {
                         "/swagger-resources/**",
                         "/v3/api-docs/**",
                         "/api/members/login", "/api/members/token/regenerate", "/api/members/join",
-                        "/api/members/email/auth","/api/members/email/auth/verify","/api/members/email/duplicate",
-                        "/api/members/kakao/callback","/api/members/naver/callback", "/api/members/nickname/duplicate",
-                        "/api/members/password/update","/api/members/phone/auth","/api/members/phone/auth/**",
-                        "/api/item/today", "/api/item/topsale","/api/item/steady", "/api/count/tags/item",
-                        "/api/delivery-date/item" ,"/api/item/main", "/api/item/{itemId}/related" ,"/api/order/api/nologin/order"
+                        "/api/members/email/auth", "/api/members/email/auth/verify", "/api/members/email/duplicate",
+                        "/api/members/kakao/callback", "/api/members/naver/callback", "/api/members/nickname/duplicate",
+                        "/api/members/password/update", "/api/members/phone/auth", "/api/members/phone/auth/**",
+                        "/api/item/today", "/api/item/topsale", "/api/item/steady", "/api/count/tags/item",
+                        "/api/delivery-date/item", "/api/item/main", "/api/item/{itemId}/related", "/api/order/api/nologin/order",
+                        "api/seller/item/{itemId}",
+                        "/api/setItemData"
                 );
     }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
 

--- a/src/main/java/com/umc/TheGoods/test/TestController.java
+++ b/src/main/java/com/umc/TheGoods/test/TestController.java
@@ -36,8 +36,8 @@ public class TestController {
     public ApiResponse<TestResponseDTO.addItemDTO> setItemData(
             @RequestPart(value = "request") @Valid TestRequestDTO.setItemDTO request,
             @RequestPart(value = "itemThumbnail") MultipartFile itemThumbnail,
-            @RequestPart(value = "itemImgList", required = false) List<MultipartFile> itemImgList,
-            @RequestPart(value = "sellerProfile") MultipartFile sellerProfile
+            @RequestPart(value = "itemImgList", required = false) List<MultipartFile> itemImgList
+            //@RequestPart(value = "sellerProfile") MultipartFile sellerProfile
     ) {
         log.info("=========================== 회원 찾기 시작 =======================");
 
@@ -52,18 +52,19 @@ public class TestController {
             termAgreeList.add(true);
             termAgreeList.add(true);
             termAgreeList.add(true);
+            termAgreeList.add(true);
 
 
             // 선호 카테고리 랜덤 설정
             List<Long> memberCategoryList = new ArrayList<>();
             long leftLimit = 1L;
-            long rightLimit = 6L;
+            long rightLimit = 4L;
             long generatedLong = leftLimit + (long) (Math.random() * (rightLimit - leftLimit));
             memberCategoryList.add(generatedLong);
 
             // 회원 가입
             TestRequestDTO.setMemberDTO sellerDTO = new TestRequestDTO.setMemberDTO(request.sellerName, request.itemUuid, termAgreeList, memberCategoryList);
-            seller = testCommandService.addMember(sellerDTO, sellerProfile);
+            seller = testCommandService.addMember(sellerDTO);
         } else {
             log.info("=========================== 닉네임으로 회원 찾음 ================================");
 
@@ -97,8 +98,8 @@ public class TestController {
         List<Boolean> termAgreeList = new ArrayList<>();
         termAgreeList.add(true);
 
-        MemberRequestDTO.JoinDTO joinBuyerDTO = new MemberRequestDTO.JoinDTO("구매자 테스트 계정","테스트", "12345678", "test@gmail.com", date, "01012345678", Gender.MALE, termAgreeList);
-        MemberRequestDTO.JoinDTO noLoginUserDTO = new MemberRequestDTO.JoinDTO("no_login_user","비회원", "12345678", "nologinuser@gmail.com", date, "01087654321", Gender.MALE, termAgreeList);
+        MemberRequestDTO.JoinDTO joinBuyerDTO = new MemberRequestDTO.JoinDTO("구매자 테스트 계정", "테스트", "12345678", "test@gmail.com", date, "01012345678", Gender.MALE, termAgreeList);
+        MemberRequestDTO.JoinDTO noLoginUserDTO = new MemberRequestDTO.JoinDTO("no_login_user", "비회원", "12345678", "nologinuser@gmail.com", date, "01087654321", Gender.MALE, termAgreeList);
 
 
         memberCommandService.join(joinBuyerDTO);

--- a/src/main/java/com/umc/TheGoods/test/TestConverter.java
+++ b/src/main/java/com/umc/TheGoods/test/TestConverter.java
@@ -26,7 +26,7 @@ public class TestConverter {
         return Member.builder()
                 .nickname(request.getNickname())
                 .password(encoder.encode("12345678"))
-                .email(request.getUuid() + "@gmail.com")
+                .email(request.getNickname() + "@gmail.com")
                 .birthday(date)
                 .gender(Gender.FEMALE)
                 .phone("01012345678")

--- a/src/main/java/com/umc/TheGoods/test/service/TestCommandService.java
+++ b/src/main/java/com/umc/TheGoods/test/service/TestCommandService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface TestCommandService {
 
-    Member addMember(TestRequestDTO.setMemberDTO request, MultipartFile multipartFile);
+    Member addMember(TestRequestDTO.setMemberDTO request);
 
     Item addItem(Member member, TestRequestDTO.setItemDTO request, MultipartFile itemThumbnail, List<MultipartFile> itemImgList);
 }

--- a/src/main/java/com/umc/TheGoods/test/service/TestCommandServiceImpl.java
+++ b/src/main/java/com/umc/TheGoods/test/service/TestCommandServiceImpl.java
@@ -5,7 +5,6 @@ import com.umc.TheGoods.apiPayload.exception.handler.MemberHandler;
 import com.umc.TheGoods.converter.item.ItemOptionConverter;
 import com.umc.TheGoods.converter.member.MemberConverter;
 import com.umc.TheGoods.domain.images.ItemImg;
-import com.umc.TheGoods.domain.images.ProfileImg;
 import com.umc.TheGoods.domain.item.Category;
 import com.umc.TheGoods.domain.item.Item;
 import com.umc.TheGoods.domain.item.ItemOption;
@@ -57,7 +56,7 @@ public class TestCommandServiceImpl implements TestCommandService {
 
 
     @Override
-    public Member addMember(TestRequestDTO.setMemberDTO request, MultipartFile multipartFile) {
+    public Member addMember(TestRequestDTO.setMemberDTO request) {
         // userName 중복 체크
         memberRepository.findByNickname(request.getNickname())
                 .ifPresent(user -> {
@@ -67,7 +66,6 @@ public class TestCommandServiceImpl implements TestCommandService {
 
         //저장
         Member member = TestConverter.toTestMember(request, encoder);
-
 
         // 약관동의 저장 로직
         HashMap<Term, Boolean> termMap = new HashMap<>();
@@ -80,12 +78,6 @@ public class TestCommandServiceImpl implements TestCommandService {
         memberTermList.forEach(memberTerm -> {
             memberTerm.setMember(member);
         });
-
-        String profileUrl = utilService.uploadS3Img("member", multipartFile);
-        ProfileImg profileImg = TestConverter.toProfileImg(profileUrl);
-        profileImg.setMember(member);
-
-        profileImgRepository.save(profileImg);
 
         memberRepository.save(member);
         return member;


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
테스트 데이터 등록용 API 수정 및 SwaggerConfig 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 테스트 데이터 등록용 API 추가
- SwaggerConfig에 "/api/seller/item/{itemId}",  "/api/setItemData", "/api/search/item" 경로는 로그인 없이도 접근 가능하도록 수정

## ⏳ 작업 내용
- [x] 테스트 데이터 등록용 API 추가
- [x] SwaggerConfig 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

